### PR TITLE
OOTB: GNSS stub + self position updates (11.4)

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -7,6 +7,9 @@
 #include "platform/device_id.h"
 #include "platform/timebase.h"
 #include "services/ble_service.h"
+#include "services/gnss_stub_service.h"
+#include "services/self_update_policy.h"
+#include "utils/geo_utils.h"
 
 namespace naviga {
 
@@ -16,12 +19,15 @@ constexpr const char* kFirmwareVersion = "ootb-11.3-ble";
 
 NodeTable node_table;
 BleService ble_service;
+GnssStubService gnss_stub;
+SelfUpdatePolicy self_policy;
 
 } // namespace
 
 void AppServices::init() {
   last_heartbeat_ms_ = 0;
   last_summary_ms_ = 0;
+  fix_logged_ = false;
 
   const auto& profile = get_hw_profile();
 
@@ -37,6 +43,8 @@ void AppServices::init() {
   const uint64_t full_id = get_device_full_id_u64();
   const uint16_t short_id = get_device_short_id_u16();
   node_table.init_self(full_id, short_id, uptime_ms());
+  gnss_stub.init(full_id);
+  self_policy.init();
 
   char full_id_hex[20] = {0};
   char mac_hex[13] = {0};
@@ -65,6 +73,48 @@ void AppServices::init() {
 }
 
 void AppServices::tick(uint32_t now_ms) {
+  if (gnss_stub.tick(now_ms)) {
+    const GnssSample sample = gnss_stub.latest();
+    if (sample.has_fix && !fix_logged_) {
+      Serial.println("GNSS: FIX acquired");
+      fix_logged_ = true;
+    }
+
+    const SelfUpdateDecision decision = self_policy.evaluate(now_ms, sample);
+    if (decision.reason != SelfUpdateReason::NONE) {
+      self_policy.commit(now_ms, sample);
+      node_table.update_self_position(sample.lat_e7, sample.lon_e7, now_ms);
+
+      const char* reason_str = "NONE";
+      switch (decision.reason) {
+        case SelfUpdateReason::DISTANCE:
+          reason_str = "DISTANCE";
+          break;
+        case SelfUpdateReason::MAX_SILENCE:
+          reason_str = "MAX_SILENCE";
+          break;
+        case SelfUpdateReason::FIRST_FIX:
+          reason_str = "FIRST_FIX";
+          break;
+        case SelfUpdateReason::NONE:
+        default:
+          reason_str = "NONE";
+          break;
+      }
+
+      Serial.print("SELF_POS: updated reason=");
+      Serial.print(reason_str);
+      Serial.print(" lat_e7=");
+      Serial.print(sample.lat_e7);
+      Serial.print(" lon_e7=");
+      Serial.print(sample.lon_e7);
+      Serial.print(" d=");
+      Serial.print(decision.distance_m, 2);
+      Serial.print(" dt=");
+      Serial.println(decision.dt_ms);
+    }
+  }
+
   if ((now_ms - last_heartbeat_ms_) >= 1000U) {
     last_heartbeat_ms_ = now_ms;
     Serial.print("tick: ");

--- a/firmware/src/app/app_services.h
+++ b/firmware/src/app/app_services.h
@@ -12,6 +12,7 @@ class AppServices {
  private:
   uint32_t last_heartbeat_ms_ = 0;
   uint32_t last_summary_ms_ = 0;
+  bool fix_logged_ = false;
 };
 
 } // namespace naviga

--- a/firmware/src/services/gnss_stub_service.cpp
+++ b/firmware/src/services/gnss_stub_service.cpp
@@ -1,0 +1,74 @@
+#include "services/gnss_stub_service.h"
+
+#include <cmath>
+
+namespace naviga {
+
+namespace {
+
+constexpr int32_t kBaseLatE7 = 571844000; // Rostov Veliky, RU (approx).
+constexpr int32_t kBaseLonE7 = 383663000; // Rostov Veliky, RU (approx).
+constexpr double kEarthRadiusM = 6371000.0;
+
+constexpr bool kForceNoFix = false;
+
+uint32_t lcg_next(uint32_t& state) {
+  state = state * 1664525u + 1013904223u;
+  return state;
+}
+
+void apply_move_m(int32_t& lat_e7, int32_t& lon_e7, double east_m, double north_m) {
+  const double lat_rad = (lat_e7 / 1e7) * M_PI / 180.0;
+  const double d_lat = north_m / kEarthRadiusM;
+  const double d_lon = east_m / (kEarthRadiusM * std::cos(lat_rad));
+
+  const double new_lat = lat_rad + d_lat;
+  const double new_lon = (lon_e7 / 1e7) * M_PI / 180.0 + d_lon;
+
+  lat_e7 = static_cast<int32_t>(new_lat * 180.0 / M_PI * 1e7);
+  lon_e7 = static_cast<int32_t>(new_lon * 180.0 / M_PI * 1e7);
+}
+
+} // namespace
+
+void GnssStubService::init(uint64_t seed) {
+  rng_state_ = static_cast<uint32_t>(seed ^ (seed >> 32));
+  last_sample_ms_ = 0;
+  sample_ = {
+      .has_fix = !kForceNoFix,
+      .lat_e7 = kBaseLatE7,
+      .lon_e7 = kBaseLonE7,
+  };
+}
+
+bool GnssStubService::tick(uint32_t now_ms) {
+  if (last_sample_ms_ != 0 && (now_ms - last_sample_ms_) < 1000U) {
+    return false;
+  }
+  last_sample_ms_ = now_ms;
+
+  if (kForceNoFix) {
+    sample_.has_fix = false;
+    return true;
+  }
+
+  sample_.has_fix = true;
+
+  // Deterministic drift: sometimes <25m, sometimes >25m.
+  const uint32_t r = lcg_next(rng_state_);
+  const bool small_step = (r % 5u) == 0u;
+  const double step_m = small_step ? (5.0 + (r % 10u)) : (30.0 + (r % 10u));
+  const double angle = (lcg_next(rng_state_) % 360u) * (M_PI / 180.0);
+
+  const double north_m = step_m * std::cos(angle);
+  const double east_m = step_m * std::sin(angle);
+  apply_move_m(sample_.lat_e7, sample_.lon_e7, east_m, north_m);
+
+  return true;
+}
+
+GnssSample GnssStubService::latest() const {
+  return sample_;
+}
+
+} // namespace naviga

--- a/firmware/src/services/gnss_stub_service.h
+++ b/firmware/src/services/gnss_stub_service.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace naviga {
+
+struct GnssSample {
+  bool has_fix;
+  int32_t lat_e7;
+  int32_t lon_e7;
+};
+
+class GnssStubService {
+ public:
+  void init(uint64_t seed);
+  bool tick(uint32_t now_ms);
+  GnssSample latest() const;
+
+ private:
+  uint32_t rng_state_ = 0;
+  uint32_t last_sample_ms_ = 0;
+  GnssSample sample_{};
+};
+
+} // namespace naviga

--- a/firmware/src/services/self_update_policy.cpp
+++ b/firmware/src/services/self_update_policy.cpp
@@ -1,0 +1,53 @@
+#include "services/self_update_policy.h"
+
+#include "utils/geo_utils.h"
+
+namespace naviga {
+
+namespace {
+
+constexpr double kMinDistanceM = 25.0;
+constexpr uint32_t kMinTimeMs = 18000;
+constexpr uint32_t kMaxSilenceMs = 72000;
+
+} // namespace
+
+void SelfUpdatePolicy::init() {
+  has_commit_ = false;
+  last_committed_ms_ = 0;
+  last_lat_e7_ = 0;
+  last_lon_e7_ = 0;
+}
+
+SelfUpdateDecision SelfUpdatePolicy::evaluate(uint32_t now_ms, const GnssSample& sample) {
+  if (!sample.has_fix) {
+    return {SelfUpdateReason::NONE, 0.0, 0};
+  }
+
+  if (!has_commit_) {
+    return {SelfUpdateReason::FIRST_FIX, 0.0, 0};
+  }
+
+  const uint32_t dt_ms = now_ms - last_committed_ms_;
+  const double distance_m =
+      distance_m_e7(last_lat_e7_, last_lon_e7_, sample.lat_e7, sample.lon_e7);
+
+  if (dt_ms >= kMaxSilenceMs) {
+    return {SelfUpdateReason::MAX_SILENCE, distance_m, dt_ms};
+  }
+
+  if (dt_ms >= kMinTimeMs && distance_m >= kMinDistanceM) {
+    return {SelfUpdateReason::DISTANCE, distance_m, dt_ms};
+  }
+
+  return {SelfUpdateReason::NONE, distance_m, dt_ms};
+}
+
+void SelfUpdatePolicy::commit(uint32_t now_ms, const GnssSample& sample) {
+  has_commit_ = true;
+  last_committed_ms_ = now_ms;
+  last_lat_e7_ = sample.lat_e7;
+  last_lon_e7_ = sample.lon_e7;
+}
+
+} // namespace naviga

--- a/firmware/src/services/self_update_policy.h
+++ b/firmware/src/services/self_update_policy.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+
+#include "services/gnss_stub_service.h"
+
+namespace naviga {
+
+enum class SelfUpdateReason {
+  NONE,
+  DISTANCE,
+  MAX_SILENCE,
+  FIRST_FIX,
+};
+
+struct SelfUpdateDecision {
+  SelfUpdateReason reason;
+  double distance_m;
+  uint32_t dt_ms;
+};
+
+class SelfUpdatePolicy {
+ public:
+  void init();
+  SelfUpdateDecision evaluate(uint32_t now_ms, const GnssSample& sample);
+  void commit(uint32_t now_ms, const GnssSample& sample);
+
+ private:
+  bool has_commit_ = false;
+  uint32_t last_committed_ms_ = 0;
+  int32_t last_lat_e7_ = 0;
+  int32_t last_lon_e7_ = 0;
+};
+
+} // namespace naviga

--- a/firmware/src/utils/geo_utils.cpp
+++ b/firmware/src/utils/geo_utils.cpp
@@ -1,0 +1,45 @@
+#include "utils/geo_utils.h"
+
+#include <cmath>
+
+namespace naviga {
+
+namespace {
+
+constexpr double kEarthRadiusM = 6371000.0;
+
+double to_rad_e7(int32_t deg_e7) {
+  return (deg_e7 / 1e7) * M_PI / 180.0;
+}
+
+} // namespace
+
+// Equirectangular approximation for local distances.
+double distance_m_e7(int32_t lat1_e7, int32_t lon1_e7, int32_t lat2_e7, int32_t lon2_e7) {
+  const double lat1 = to_rad_e7(lat1_e7);
+  const double lat2 = to_rad_e7(lat2_e7);
+  const double lon1 = to_rad_e7(lon1_e7);
+  const double lon2 = to_rad_e7(lon2_e7);
+
+  const double x = (lon2 - lon1) * std::cos((lat1 + lat2) * 0.5);
+  const double y = (lat2 - lat1);
+  return std::sqrt(x * x + y * y) * kEarthRadiusM;
+}
+
+double bearing_deg_e7(int32_t lat1_e7, int32_t lon1_e7, int32_t lat2_e7, int32_t lon2_e7) {
+  const double lat1 = to_rad_e7(lat1_e7);
+  const double lat2 = to_rad_e7(lat2_e7);
+  const double lon1 = to_rad_e7(lon1_e7);
+  const double lon2 = to_rad_e7(lon2_e7);
+
+  const double x = (lon2 - lon1) * std::cos((lat1 + lat2) * 0.5);
+  const double y = (lat2 - lat1);
+  const double bearing_rad = std::atan2(x, y);
+  double bearing_deg = bearing_rad * 180.0 / M_PI;
+  if (bearing_deg < 0.0) {
+    bearing_deg += 360.0;
+  }
+  return bearing_deg;
+}
+
+} // namespace naviga

--- a/firmware/src/utils/geo_utils.h
+++ b/firmware/src/utils/geo_utils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+
+namespace naviga {
+
+double distance_m_e7(int32_t lat1_e7, int32_t lon1_e7, int32_t lat2_e7, int32_t lon2_e7);
+double bearing_deg_e7(int32_t lat1_e7, int32_t lon1_e7, int32_t lat2_e7, int32_t lon2_e7);
+
+} // namespace naviga


### PR DESCRIPTION
## Summary
- add GNSS stub service with deterministic drift
- add geo utils + self update policy (distance/time + max_silence)
- wire self position updates via AppServices

## Checklist
- [x] Issue #11 item 11.4 (GNSS stub + geo utils + self position updates)

## Test plan
- [x] `pio run -e devkit_e220_oled`
- [x] `pio run -e devkit_e220_oled_gnss`

Refs #11