### PR TITLE
#19 Step 2: platform implementations + remove Arduino usage from app/services

### DIFF
--- a/firmware/lib/NavigaCore/include/naviga/platform/clock.h
+++ b/firmware/lib/NavigaCore/include/naviga/platform/clock.h
@@ -21,6 +21,11 @@ struct IClock {
    * @brief Return time since boot in milliseconds.
    */
   virtual millis_t uptime_ms() const = 0;
+
+  /**
+   * @brief Sleep for the specified number of milliseconds.
+   */
+  virtual void sleep_ms(millis_t duration_ms) const = 0;
 };
 
 } // namespace naviga::platform

--- a/firmware/src/platform/arduino_clock.cpp
+++ b/firmware/src/platform/arduino_clock.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file arduino_clock.cpp
+ * @brief Arduino-backed platform clock.
+ */
+#include "platform/arduino_clock.h"
+
+#include <Arduino.h>
+
+namespace naviga::platform {
+
+millis_t ArduinoClock::uptime_ms() const {
+  return ::millis();
+}
+
+void ArduinoClock::sleep_ms(millis_t duration_ms) const {
+  ::delay(duration_ms);
+}
+
+} // namespace naviga::platform

--- a/firmware/src/platform/arduino_clock.h
+++ b/firmware/src/platform/arduino_clock.h
@@ -1,0 +1,20 @@
+/**
+ * @file arduino_clock.h
+ * @brief Arduino-backed platform clock.
+ */
+#pragma once
+
+#include "naviga/platform/clock.h"
+
+namespace naviga::platform {
+
+/**
+ * @brief Arduino clock implementation.
+ */
+class ArduinoClock final : public IClock {
+ public:
+  millis_t uptime_ms() const override;
+  void sleep_ms(millis_t duration_ms) const override;
+};
+
+} // namespace naviga::platform

--- a/firmware/src/platform/arduino_gpio.cpp
+++ b/firmware/src/platform/arduino_gpio.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file arduino_gpio.cpp
+ * @brief Arduino GPIO helpers for platform layer.
+ */
+#include "platform/arduino_gpio.h"
+
+#include <Arduino.h>
+
+namespace naviga::platform {
+
+void configure_input_pullup(int pin) {
+  ::pinMode(pin, INPUT_PULLUP);
+}
+
+bool read_digital(int pin) {
+  return ::digitalRead(pin) == HIGH;
+}
+
+} // namespace naviga::platform

--- a/firmware/src/platform/arduino_gpio.h
+++ b/firmware/src/platform/arduino_gpio.h
@@ -1,0 +1,22 @@
+/**
+ * @file arduino_gpio.h
+ * @brief Arduino GPIO helpers for platform layer.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace naviga::platform {
+
+/**
+ * @brief Configure GPIO as input with pull-up.
+ */
+void configure_input_pullup(int pin);
+
+/**
+ * @brief Read GPIO digital value.
+ * @return true if HIGH, false if LOW.
+ */
+bool read_digital(int pin);
+
+} // namespace naviga::platform

--- a/firmware/src/platform/arduino_logger.cpp
+++ b/firmware/src/platform/arduino_logger.cpp
@@ -1,0 +1,22 @@
+/**
+ * @file arduino_logger.cpp
+ * @brief Arduino-backed logger implementation.
+ */
+#include "platform/arduino_logger.h"
+
+#include <Arduino.h>
+
+namespace naviga::platform {
+
+void ArduinoLogger::log(LogLevel level, const char* tag, const char* msg) {
+  (void)level;
+  (void)tag;
+  if (!msg) {
+    return;
+  }
+  if (Serial) {
+    Serial.println(msg);
+  }
+}
+
+} // namespace naviga::platform

--- a/firmware/src/platform/arduino_logger.h
+++ b/firmware/src/platform/arduino_logger.h
@@ -1,0 +1,19 @@
+/**
+ * @file arduino_logger.h
+ * @brief Arduino-backed logger implementation.
+ */
+#pragma once
+
+#include "naviga/platform/log.h"
+
+namespace naviga::platform {
+
+/**
+ * @brief Arduino logger implementation (Serial).
+ */
+class ArduinoLogger final : public ILogger {
+ public:
+  void log(LogLevel level, const char* tag, const char* msg) override;
+};
+
+} // namespace naviga::platform

--- a/firmware/src/platform/device_id.cpp
+++ b/firmware/src/platform/device_id.cpp
@@ -44,6 +44,19 @@ void get_device_mac_bytes(uint8_t out_mac[6]) {
 uint64_t get_device_full_id_u64() {
   uint8_t mac[6] = {0};
   get_device_mac_bytes(mac);
+  return full_id_from_mac(mac);
+}
+
+uint16_t get_device_short_id_u16() {
+  uint8_t mac[6] = {0};
+  get_device_mac_bytes(mac);
+  return short_id_from_mac(mac);
+}
+
+uint64_t full_id_from_mac(const uint8_t mac[6]) {
+  if (!mac) {
+    return 0;
+  }
   uint64_t id = 0;
   // Canonical order: MAC bytes [0..5] map to hex string and full_id_u64.
   // full_id_u64 = 0x0000 <mac[0]..mac[5]> (big-endian packing into lower 6 bytes).
@@ -53,9 +66,10 @@ uint64_t get_device_full_id_u64() {
   return id;
 }
 
-uint16_t get_device_short_id_u16() {
-  uint8_t mac[6] = {0};
-  get_device_mac_bytes(mac);
+uint16_t short_id_from_mac(const uint8_t mac[6]) {
+  if (!mac) {
+    return 0;
+  }
   // CRC16-CCITT-FALSE over the 6 MAC bytes.
   return crc16_ccitt_false(mac, 6);
 }

--- a/firmware/src/platform/device_id.h
+++ b/firmware/src/platform/device_id.h
@@ -9,6 +9,9 @@ uint64_t get_device_full_id_u64();
 uint16_t get_device_short_id_u16();
 void get_device_mac_bytes(uint8_t out_mac[6]);
 
+uint64_t full_id_from_mac(const uint8_t mac[6]);
+uint16_t short_id_from_mac(const uint8_t mac[6]);
+
 void format_full_id_u64_hex(uint64_t full_id, char* out, size_t out_len);
 void format_full_id_mac_hex(const uint8_t mac[6], char* out, size_t out_len);
 void format_short_id_hex(uint16_t short_id, char* out, size_t out_len);

--- a/firmware/src/platform/esp_device_id_provider.cpp
+++ b/firmware/src/platform/esp_device_id_provider.cpp
@@ -1,0 +1,22 @@
+/**
+ * @file esp_device_id_provider.cpp
+ * @brief ESP32 device ID provider (efuse MAC).
+ */
+#include "platform/esp_device_id_provider.h"
+
+#include <cstring>
+
+#include "esp_system.h"
+
+namespace naviga::platform {
+
+DeviceId EspDeviceIdProvider::get() const {
+  DeviceId id{};
+  uint8_t base_mac[6] = {0};
+  if (esp_efuse_mac_get_default(base_mac) == ESP_OK) {
+    std::memcpy(id.bytes, base_mac, sizeof(id.bytes));
+  }
+  return id;
+}
+
+} // namespace naviga::platform

--- a/firmware/src/platform/esp_device_id_provider.h
+++ b/firmware/src/platform/esp_device_id_provider.h
@@ -1,0 +1,19 @@
+/**
+ * @file esp_device_id_provider.h
+ * @brief ESP32 device ID provider (efuse MAC).
+ */
+#pragma once
+
+#include "naviga/platform/device_id.h"
+
+namespace naviga::platform {
+
+/**
+ * @brief ESP32 implementation of device ID provider.
+ */
+class EspDeviceIdProvider final : public IDeviceIdProvider {
+ public:
+  DeviceId get() const override;
+};
+
+} // namespace naviga::platform

--- a/firmware/src/services/ble_service.h
+++ b/firmware/src/services/ble_service.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "naviga/platform/log.h"
+
 namespace naviga {
 
 struct DeviceInfoData {
@@ -18,10 +20,12 @@ class NodeTable;
 
 class BleService {
  public:
-  void init(const DeviceInfoData& info, const NodeTable* node_table);
+  void init(const DeviceInfoData& info, const NodeTable* node_table,
+            platform::ILogger* logger);
 
  private:
   const NodeTable* node_table_ = nullptr;
+  platform::ILogger* logger_ = nullptr;
 };
 
 } // namespace naviga


### PR DESCRIPTION
Refs #19

## Summary
- Add platform adapters: Arduino clock/logger/gpio and ESP device ID provider.
- Route app/services logging and delay through platform interfaces; remove direct Arduino.h/Serial/delay usage from app/services.
- Extend IClock with sleep_ms for settle delay.

## Test plan
- `pio test -e test_native`
- `pio run -e devkit_e220_oled`
- `pio run -e devkit_e220_oled_gnss`