### PR TITLE
Issue #22: ESP32 IBleTransport driver (core + adapter)

### DIFF
--- a/docs/project/ootb_progress_inventory.md
+++ b/docs/project/ootb_progress_inventory.md
@@ -58,7 +58,7 @@
 | [#19](https://github.com/AlexanderTsarkov/naviga-app/issues/19) | 2.1 Firmware module tree | Code structure | Done | PR [#60](https://github.com/AlexanderTsarkov/naviga-app/pull/60), PR [#61](https://github.com/AlexanderTsarkov/naviga-app/pull/61) — Core purity: platform abstractions + platform adapters; removed Arduino/Serial/delay from app/services; CI guardrails added. |
 | [#20](https://github.com/AlexanderTsarkov/naviga-app/issues/20) | 2.2 Logging v0 | Code | Done | PR [#65](https://github.com/AlexanderTsarkov/naviga-app/pull/65) — Logging v0: RAM ring buffer + UART export; TX/RX, NodeTable update, BLE connect/read events; test_native. |
 | [#21](https://github.com/AlexanderTsarkov/naviga-app/issues/21) | 2.3 HAL radio driver | Code | Open | N/A |
-| [#22](https://github.com/AlexanderTsarkov/naviga-app/issues/22) | 2.4 HAL BLE transport | Code | Open | N/A |
+| [#22](https://github.com/AlexanderTsarkov/naviga-app/issues/22) | 2.4 HAL BLE transport | Code | Done | `firmware/src/platform/ble_transport_core.{h,cpp}`, `firmware/src/platform/ble_esp32_transport.{h,cpp}`, `firmware/test/test_ble_transport_core/test_ble_transport_core.cpp` |
 | [#23](https://github.com/AlexanderTsarkov/naviga-app/issues/23) | 2.5 GEO_BEACON codec | Code | Done | PR [#63](https://github.com/AlexanderTsarkov/naviga-app/pull/63). GEO_BEACON codec: fixed 24-byte core, little-endian; decode ignores trailing bytes; pos_valid==0 skips range-check (fields parsed as-is); unit tests (test_native). |
 | [#24](https://github.com/AlexanderTsarkov/naviga-app/issues/24) | 2.6 NodeTable domain | Code | Open | N/A |
 | [#25](https://github.com/AlexanderTsarkov/naviga-app/issues/25) | 2.7 Beacon logic | Code | Open | N/A |

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -37,7 +37,10 @@ build_flags =
 [env:test_native]
 platform = native
 test_framework = unity
-test_build_src = false
+test_build_src = true
 build_flags =
   -std=gnu++11
   -DHW_PROFILE_DEVKIT_E220_OLED
+build_src_filter =
+  -<*>
+  +<platform/ble_transport_core.cpp>

--- a/firmware/src/platform/ble_esp32_transport.cpp
+++ b/firmware/src/platform/ble_esp32_transport.cpp
@@ -1,0 +1,129 @@
+#include "platform/ble_esp32_transport.h"
+
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP32)
+
+#include <BLEDevice.h>
+#include <BLEServer.h>
+#include <BLEUtils.h>
+
+namespace naviga {
+
+namespace {
+
+constexpr char kServiceUuid[] = "6e4f0001-1b9a-4c3a-9a3b-000000000001";
+constexpr char kDeviceInfoUuid[] = "6e4f0002-1b9a-4c3a-9a3b-000000000001";
+constexpr char kNodeTablePage0Uuid[] = "6e4f0003-1b9a-4c3a-9a3b-000000000001";
+constexpr char kNodeTablePage1Uuid[] = "6e4f0004-1b9a-4c3a-9a3b-000000000001";
+constexpr char kNodeTablePage2Uuid[] = "6e4f0005-1b9a-4c3a-9a3b-000000000001";
+constexpr char kNodeTablePage3Uuid[] = "6e4f0006-1b9a-4c3a-9a3b-000000000001";
+
+class NavigaServerCallbacks : public BLEServerCallbacks {
+ public:
+  void onDisconnect(BLEServer* server) override {
+    if (server) {
+      server->getAdvertising()->start();
+    }
+  }
+};
+
+class DeviceInfoCallbacks : public BLECharacteristicCallbacks {
+ public:
+  explicit DeviceInfoCallbacks(BleTransportCore* core) : core_(core) {}
+
+  void onRead(BLECharacteristic* characteristic) override {
+    if (!characteristic || !core_) {
+      return;
+    }
+    const uint8_t* data = core_->device_info_data();
+    const size_t len = core_->device_info_len();
+    characteristic->setValue(const_cast<uint8_t*>(data), len);
+  }
+
+ private:
+  BleTransportCore* core_ = nullptr;
+};
+
+class NodeTablePageCallbacks : public BLECharacteristicCallbacks {
+ public:
+  NodeTablePageCallbacks(BleTransportCore* core, uint8_t page_index)
+      : core_(core), page_index_(page_index) {}
+
+  void onRead(BLECharacteristic* characteristic) override {
+    if (!characteristic || !core_) {
+      return;
+    }
+    const uint8_t* data = core_->page_data(page_index_);
+    const size_t len = core_->page_len(page_index_);
+    characteristic->setValue(const_cast<uint8_t*>(data), len);
+  }
+
+ private:
+  BleTransportCore* core_ = nullptr;
+  uint8_t page_index_ = 0;
+};
+
+} // namespace
+
+BleEsp32Transport::BleEsp32Transport() = default;
+
+void BleEsp32Transport::init() {
+  BLEDevice::init("Naviga");
+
+  server_ = BLEDevice::createServer();
+  server_->setCallbacks(new NavigaServerCallbacks());
+
+  service_ = server_->createService(kServiceUuid);
+
+  device_info_char_ = service_->createCharacteristic(kDeviceInfoUuid, BLECharacteristic::PROPERTY_READ);
+  device_info_char_->setCallbacks(new DeviceInfoCallbacks(&core_));
+
+  page_chars_[0] = service_->createCharacteristic(kNodeTablePage0Uuid, BLECharacteristic::PROPERTY_READ);
+  page_chars_[1] = service_->createCharacteristic(kNodeTablePage1Uuid, BLECharacteristic::PROPERTY_READ);
+  page_chars_[2] = service_->createCharacteristic(kNodeTablePage2Uuid, BLECharacteristic::PROPERTY_READ);
+  page_chars_[3] = service_->createCharacteristic(kNodeTablePage3Uuid, BLECharacteristic::PROPERTY_READ);
+
+  for (uint8_t i = 0; i < BleTransportCore::kPageCount; ++i) {
+    page_chars_[i]->setCallbacks(new NodeTablePageCallbacks(&core_, i));
+  }
+
+  service_->start();
+
+  advertising_ = BLEDevice::getAdvertising();
+  advertising_->addServiceUUID(kServiceUuid);
+  advertising_->setScanResponse(true);
+  advertising_->start();
+}
+
+void BleEsp32Transport::set_device_info(const uint8_t* data, size_t len) {
+  core_.set_device_info(data, len);
+}
+
+void BleEsp32Transport::set_node_table_page(uint8_t page_index,
+                                            const uint8_t* data,
+                                            size_t len) {
+  core_.set_node_table_page(page_index, data, len);
+}
+
+} // namespace naviga
+
+#else
+
+namespace naviga {
+
+BleEsp32Transport::BleEsp32Transport() = default;
+
+void BleEsp32Transport::init() {}
+
+void BleEsp32Transport::set_device_info(const uint8_t* data, size_t len) {
+  core_.set_device_info(data, len);
+}
+
+void BleEsp32Transport::set_node_table_page(uint8_t page_index,
+                                            const uint8_t* data,
+                                            size_t len) {
+  core_.set_node_table_page(page_index, data, len);
+}
+
+} // namespace naviga
+
+#endif

--- a/firmware/src/platform/ble_esp32_transport.h
+++ b/firmware/src/platform/ble_esp32_transport.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "naviga/hal/interfaces.h"
+#include "platform/ble_transport_core.h"
+
+class BLECharacteristic;
+class BLEServer;
+class BLEService;
+class BLEAdvertising;
+
+namespace naviga {
+
+class BleEsp32Transport : public IBleTransport {
+ public:
+  BleEsp32Transport();
+
+  void init();
+
+  void set_device_info(const uint8_t* data, size_t len) override;
+  void set_node_table_page(uint8_t page_index, const uint8_t* data, size_t len) override;
+
+ private:
+  BleTransportCore core_;
+
+  BLEServer* server_ = nullptr;
+  BLEService* service_ = nullptr;
+  BLEAdvertising* advertising_ = nullptr;
+  BLECharacteristic* device_info_char_ = nullptr;
+  BLECharacteristic* page_chars_[BleTransportCore::kPageCount] = {nullptr, nullptr, nullptr, nullptr};
+};
+
+} // namespace naviga

--- a/firmware/src/platform/ble_transport_core.cpp
+++ b/firmware/src/platform/ble_transport_core.cpp
@@ -1,0 +1,46 @@
+#include "platform/ble_transport_core.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace naviga {
+
+void BleTransportCore::set_device_info(const uint8_t* data, size_t len) {
+  const size_t copy_len = std::min(len, device_info_.size());
+  if (data && copy_len > 0) {
+    std::memcpy(device_info_.data(), data, copy_len);
+  }
+  device_info_len_ = copy_len;
+}
+
+bool BleTransportCore::set_node_table_page(uint8_t page_index,
+                                           const uint8_t* data,
+                                           size_t len) {
+  if (page_index >= kPageCount) {
+    return false;
+  }
+  const size_t copy_len = std::min(len, page_buf_[page_index].size());
+  if (data && copy_len > 0) {
+    std::memcpy(page_buf_[page_index].data(), data, copy_len);
+  }
+  page_len_[page_index] = copy_len;
+  return true;
+}
+
+const uint8_t* BleTransportCore::device_info_data() const {
+  return device_info_.data();
+}
+
+size_t BleTransportCore::device_info_len() const {
+  return device_info_len_;
+}
+
+const uint8_t* BleTransportCore::page_data(uint8_t page_index) const {
+  return page_index < kPageCount ? page_buf_[page_index].data() : nullptr;
+}
+
+size_t BleTransportCore::page_len(uint8_t page_index) const {
+  return page_index < kPageCount ? page_len_[page_index] : 0;
+}
+
+} // namespace naviga

--- a/firmware/src/platform/ble_transport_core.h
+++ b/firmware/src/platform/ble_transport_core.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace naviga {
+
+class BleTransportCore {
+ public:
+  static constexpr size_t kMaxDeviceInfoLen = 256;
+  static constexpr size_t kMaxPageLen = 256;
+  static constexpr uint8_t kPageCount = 4;
+
+  void set_device_info(const uint8_t* data, size_t len);
+  bool set_node_table_page(uint8_t page_index, const uint8_t* data, size_t len);
+
+  const uint8_t* device_info_data() const;
+  size_t device_info_len() const;
+
+  const uint8_t* page_data(uint8_t page_index) const;
+  size_t page_len(uint8_t page_index) const;
+
+ private:
+  std::array<uint8_t, kMaxDeviceInfoLen> device_info_{};
+  size_t device_info_len_ = 0;
+
+  std::array<std::array<uint8_t, kMaxPageLen>, kPageCount> page_buf_{};
+  std::array<size_t, kPageCount> page_len_ = {0, 0, 0, 0};
+};
+
+} // namespace naviga

--- a/firmware/test/test_ble_transport_core/test_ble_transport_core.cpp
+++ b/firmware/test/test_ble_transport_core/test_ble_transport_core.cpp
@@ -1,0 +1,71 @@
+#include <unity.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "platform/ble_transport_core.h"
+
+using naviga::BleTransportCore;
+
+void test_device_info_store_and_truncate() {
+  BleTransportCore core;
+  uint8_t data[BleTransportCore::kMaxDeviceInfoLen + 5] = {0};
+  for (size_t i = 0; i < sizeof(data); ++i) {
+    data[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+
+  core.set_device_info(data, sizeof(data));
+  TEST_ASSERT_EQUAL_UINT32(BleTransportCore::kMaxDeviceInfoLen, core.device_info_len());
+  const uint8_t* out = core.device_info_data();
+  TEST_ASSERT_NOT_NULL(out);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(1, out[1]);
+  TEST_ASSERT_EQUAL_UINT8(255, out[255]);
+}
+
+void test_node_table_page_bounds_and_truncate() {
+  BleTransportCore core;
+  uint8_t page[BleTransportCore::kMaxPageLen + 3] = {0};
+  for (size_t i = 0; i < sizeof(page); ++i) {
+    page[i] = static_cast<uint8_t>((i + 7) & 0xFF);
+  }
+
+  TEST_ASSERT_FALSE(core.set_node_table_page(4, page, sizeof(page)));
+  TEST_ASSERT_EQUAL_UINT32(0, core.page_len(4));
+
+  TEST_ASSERT_TRUE(core.set_node_table_page(2, page, sizeof(page)));
+  TEST_ASSERT_EQUAL_UINT32(BleTransportCore::kMaxPageLen, core.page_len(2));
+  const uint8_t* out = core.page_data(2);
+  TEST_ASSERT_NOT_NULL(out);
+  TEST_ASSERT_EQUAL_UINT8(7, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(8, out[1]);
+}
+
+void test_getters_exact_bytes() {
+  BleTransportCore core;
+  const uint8_t dev_info[] = {0xAA, 0xBB, 0xCC, 0xDD};
+  core.set_device_info(dev_info, sizeof(dev_info));
+  TEST_ASSERT_EQUAL_UINT32(sizeof(dev_info), core.device_info_len());
+  const uint8_t* out = core.device_info_data();
+  TEST_ASSERT_NOT_NULL(out);
+  for (size_t i = 0; i < sizeof(dev_info); ++i) {
+    TEST_ASSERT_EQUAL_UINT8(dev_info[i], out[i]);
+  }
+
+  const uint8_t page[] = {1, 2, 3, 4, 5};
+  core.set_node_table_page(0, page, sizeof(page));
+  TEST_ASSERT_EQUAL_UINT32(sizeof(page), core.page_len(0));
+  const uint8_t* page_out = core.page_data(0);
+  TEST_ASSERT_NOT_NULL(page_out);
+  for (size_t i = 0; i < sizeof(page); ++i) {
+    TEST_ASSERT_EQUAL_UINT8(page[i], page_out[i]);
+  }
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_device_info_store_and_truncate);
+  RUN_TEST(test_node_table_page_bounds_and_truncate);
+  RUN_TEST(test_getters_exact_bytes);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add a testable BLE transport core for storing DeviceInfo and NodeTable pages
- implement an ESP32 GATT adapter that serves core data via DeviceInfo and NodeTablePage characteristics
- add native unit tests for core storage behavior and update the OOTB inventory

## Test plan
- [x] pio test -e test_native
- [x] pio run -e esp32dev