### PR TITLE
docs: Mobile v1 progress tracking (#80)

### DIFF
--- a/docs/project/ootb_progress_inventory.md
+++ b/docs/project/ootb_progress_inventory.md
@@ -35,22 +35,27 @@
 2) **[#23] GEO_BEACON codec** — radio payload encode/decode for end-to-end.  
 3) **[#20] Logging v0** — ring-buffer + export (if needed before beacon logic).
 
-## F) Mobile v1 planned (Android-first, Flutter)
+## F) Mobile v1 (Android-first, Flutter)
 
 **Epic:** [#80](https://github.com/AlexanderTsarkov/naviga-app/issues/80)  
 **Spec:** [docs/mobile/mobile_v1_screens.md](../mobile/mobile_v1_screens.md)
 
-**Child issues:**
-- [#81](https://github.com/AlexanderTsarkov/naviga-app/issues/81) Flutter app bootstrap + module structure
-- [#82](https://github.com/AlexanderTsarkov/naviga-app/issues/82) Android permissions + BLE scan
-- [#83](https://github.com/AlexanderTsarkov/naviga-app/issues/83) BLE connection state machine
-- [#84](https://github.com/AlexanderTsarkov/naviga-app/issues/84) BLE read/notify for DeviceInfo + Health
-- [#85](https://github.com/AlexanderTsarkov/naviga-app/issues/85) NodeTableSnapshot paging + DTO decode
-- [#86](https://github.com/AlexanderTsarkov/naviga-app/issues/86) Repository + NodeTable state
-- [#87](https://github.com/AlexanderTsarkov/naviga-app/issues/87) Local cache for last NodeTable snapshot
-- [#88](https://github.com/AlexanderTsarkov/naviga-app/issues/88) Core UI screens (Connect/My Node/Nodes/Details)
-- [#89](https://github.com/AlexanderTsarkov/naviga-app/issues/89) Map v1 (flutter_map + markers)
-- [#90](https://github.com/AlexanderTsarkov/naviga-app/issues/90) Settings v1 (about + diagnostics)
+**Maintenance rule:** Every merged PR that delivers Mobile v1 work (Epic #80 / issues #81–#90) must update the tracking block below (status, PR link, key paths, verify).
+
+### F.1) Mobile v1 tracking
+
+| # | Issue | Status | PR | Key paths | Verify | Notes |
+|---|-------|--------|-----|-----------|--------|-------|
+| 81 | [#81](https://github.com/AlexanderTsarkov/naviga-app/issues/81) Flutter app bootstrap + module structure | **Done** | [#92](https://github.com/AlexanderTsarkov/naviga-app/pull/92) | `app/lib/app/`, `app/lib/features/*` (placeholders), `app/lib/shared/` | `flutter analyze`; `flutter test`; `flutter run` on Android (minSdk 28) | CI lint runs in `app/`; format check: `dart format .` in `app/` |
+| 82 | [#82](https://github.com/AlexanderTsarkov/naviga-app/issues/82) Android permissions + BLE scan | Planned | — | `app/lib/features/connect/`, BLE client TBD | analyze; test; run on device (scan list) | — |
+| 83 | [#83](https://github.com/AlexanderTsarkov/naviga-app/issues/83) BLE connection state machine | Planned | — | `app/lib/` (BLE + connect UI) | analyze; test; run (connect/disconnect) | — |
+| 84 | [#84](https://github.com/AlexanderTsarkov/naviga-app/issues/84) BLE read/notify DeviceInfo + Health | Planned | — | `app/lib/` (BLE, data layer) | analyze; test; run (DeviceInfo/Health) | — |
+| 85 | [#85](https://github.com/AlexanderTsarkov/naviga-app/issues/85) NodeTableSnapshot paging + DTO decode | Planned | — | `app/lib/` (protocol decode, DTOs) | analyze; test; decode NodeRecord v1 | — |
+| 86 | [#86](https://github.com/AlexanderTsarkov/naviga-app/issues/86) Repository + NodeTable state | Planned | — | `app/lib/` (repository, state) | analyze; test; state updates | — |
+| 87 | [#87](https://github.com/AlexanderTsarkov/naviga-app/issues/87) Local cache last NodeTable snapshot | Planned | — | `app/lib/` (storage/cache) | analyze; test; restore on reconnect | — |
+| 88 | [#88](https://github.com/AlexanderTsarkov/naviga-app/issues/88) Core UI screens (Connect/My Node/Nodes/Details) | Planned | — | `app/lib/features/`, `app/lib/shared/` | analyze; test; run (screens + data) | — |
+| 89 | [#89](https://github.com/AlexanderTsarkov/naviga-app/issues/89) Map v1 (flutter_map + markers) | Planned | — | `app/lib/features/map/` | analyze; test; run (markers) | Online tiles only (no offline) |
+| 90 | [#90](https://github.com/AlexanderTsarkov/naviga-app/issues/90) Settings v1 (about + diagnostics) | Planned | — | `app/lib/features/settings/` | analyze; test; run | No BLE config in v1 |
 
 **Definition of Done (planning):**
 - Epic + all child issues created and on Project board


### PR DESCRIPTION
## Summary
- Add **Mobile v1 tracking** block in `docs/project/ootb_progress_inventory.md` (Epic #80, issues #81–#90).
- Record **#81 Done** via PR #92 (Flutter app bootstrap), with key paths, verify checklist, and CI notes.
- Set #82–#90 as **Planned** with placeholder paths/verify.
- Add **maintenance rule:** every merged Mobile v1 PR must update this tracking section.

## Refs
- Epic [#80](https://github.com/AlexanderTsarkov/naviga-app/issues/80)
- Issue [#81](https://github.com/AlexanderTsarkov/naviga-app/issues/81) / PR [#92](https://github.com/AlexanderTsarkov/naviga-app/pull/92)

## Scope
- Docs only; no code changes. CI should remain green.

Made with [Cursor](https://cursor.com)