### PR TITLE
ui(connect): compact layout + connection indicated in list

### DIFF
--- a/app/lib/features/connect/connect_screen.dart
+++ b/app/lib/features/connect/connect_screen.dart
@@ -30,24 +30,7 @@ class ConnectScreen extends ConsumerWidget {
             onOpenAppSettings: controller.openAppSettingsPage,
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: _ConnectionCard(
-            status: state.connectionStatus,
-            connectedDeviceId: state.connectedDeviceId,
-            lastConnectedDeviceId: state.lastConnectedDeviceId,
-            onDisconnect: controller.disconnect,
-          ),
-        ),
-        if (state.connectionStatus == ConnectionStatus.connected ||
-            state.deviceInfo != null ||
-            state.isDiscoveringServices ||
-            state.telemetryError != null)
-          Padding(
-            padding: const EdgeInsets.only(left: 16, right: 16, top: 12),
-            child: _TelemetryCard(state: state),
-          ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 8),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Row(
@@ -59,9 +42,12 @@ class ConnectScreen extends ConsumerWidget {
                       : (canStartScan ? controller.startScan : null),
                   icon: Icon(scanActive ? Icons.stop : Icons.search),
                   label: Text(scanActive ? 'Stop scan' : 'Start scan'),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                  ),
                 ),
               ),
-              const SizedBox(width: 12),
+              const SizedBox(width: 8),
               _ScanStatusIndicator(isScanning: state.isScanning),
             ],
           ),
@@ -76,7 +62,7 @@ class ConnectScreen extends ConsumerWidget {
               ).textTheme.bodySmall?.copyWith(color: Colors.redAccent),
             ),
           ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 8),
         Expanded(
           child: _DeviceList(
             devices: state.deviceList,
@@ -110,9 +96,16 @@ class _ReadinessCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final lpMissing = !state.locationPermission.isGranted;
+    final lpAction = _permissionAction(
+      state,
+      onRequestPermission,
+      onOpenAppSettings,
+    );
+
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -120,40 +113,55 @@ class _ReadinessCard extends StatelessWidget {
               children: [
                 Text(
                   'Readiness',
-                  style: Theme.of(context).textTheme.titleMedium,
+                  style: Theme.of(context).textTheme.titleSmall,
                 ),
                 const Spacer(),
                 TextButton(onPressed: onRefresh, child: const Text('Refresh')),
               ],
             ),
-            const SizedBox(height: 12),
-            _ReadinessRow(
-              title: 'Bluetooth',
-              status: _bluetoothStatusLabel(state),
-              isReady: state.adapterState == BluetoothAdapterState.on,
-              actionLabel: 'Open',
-              onAction: _bluetoothNeedsAction(state) ? onOpenBluetooth : null,
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'BT:${_boolLabel(state.adapterState == BluetoothAdapterState.on)} '
+                    'LS:${_boolLabel(state.locationServiceEnabled)} '
+                    'LP:${_lpLabel(state)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 8),
-            _ReadinessRow(
-              title: 'Location services',
-              status: state.locationServiceEnabled ? 'On' : 'Off',
-              isReady: state.locationServiceEnabled,
-              actionLabel: 'Turn on',
-              onAction: state.locationServiceEnabled ? null : onOpenLocation,
-            ),
-            const SizedBox(height: 8),
-            _ReadinessRow(
-              title: 'Location permission',
-              status: _permissionStatusLabel(state),
-              isReady: state.locationPermission.isGranted,
-              actionLabel: _permissionActionLabel(state),
-              onAction: _permissionAction(
-                state,
-                onRequestPermission,
-                onOpenAppSettings,
+            if (_bluetoothNeedsAction(state) ||
+                !state.locationServiceEnabled ||
+                (lpMissing && lpAction != null))
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    if (_bluetoothNeedsAction(state))
+                      _compactActionButton(
+                        context,
+                        label: 'Open BT',
+                        onPressed: onOpenBluetooth,
+                      ),
+                    if (!state.locationServiceEnabled)
+                      _compactActionButton(
+                        context,
+                        label: 'Enable LS',
+                        onPressed: onOpenLocation,
+                      ),
+                    if (lpMissing && lpAction != null)
+                      _compactActionButton(
+                        context,
+                        label: 'Grant',
+                        onPressed: lpAction,
+                      ),
+                  ],
+                ),
               ),
-            ),
           ],
         ),
       ),
@@ -166,44 +174,10 @@ class _ReadinessCard extends StatelessWidget {
         state.adapterState == BluetoothAdapterState.unauthorized;
   }
 
-  String _bluetoothStatusLabel(ConnectState state) {
-    switch (state.adapterState) {
-      case BluetoothAdapterState.on:
-        return 'On';
-      case BluetoothAdapterState.off:
-        return 'Off';
-      case BluetoothAdapterState.unavailable:
-        return 'Unavailable';
-      case BluetoothAdapterState.unauthorized:
-        return 'Unauthorized';
-      case BluetoothAdapterState.turningOn:
-        return 'Turning on';
-      case BluetoothAdapterState.turningOff:
-        return 'Turning off';
-      case BluetoothAdapterState.unknown:
-        return 'Unknown';
-    }
-  }
+  String _boolLabel(bool value) => value ? 'On' : 'Off';
 
-  String _permissionStatusLabel(ConnectState state) {
-    final permission = state.locationPermission;
-    if (permission.isGranted) {
-      return 'Granted';
-    }
-    if (permission.isPermanentlyDenied) {
-      return 'Denied permanently';
-    }
-    if (permission.isRestricted) {
-      return 'Restricted';
-    }
-    return 'Denied';
-  }
-
-  String _permissionActionLabel(ConnectState state) {
-    if (state.locationPermission.isPermanentlyDenied) {
-      return 'Open settings';
-    }
-    return 'Grant';
+  String _lpLabel(ConnectState state) {
+    return state.locationPermission.isGranted ? 'En' : 'No';
   }
 
   VoidCallback? _permissionAction(
@@ -219,36 +193,21 @@ class _ReadinessCard extends StatelessWidget {
     }
     return requestPermission;
   }
-}
 
-class _ReadinessRow extends StatelessWidget {
-  const _ReadinessRow({
-    required this.title,
-    required this.status,
-    required this.isReady,
-    required this.actionLabel,
-    required this.onAction,
-  });
-
-  final String title;
-  final String status;
-  final bool isReady;
-  final String actionLabel;
-  final VoidCallback? onAction;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(
-          isReady ? Icons.check_circle : Icons.error_outline,
-          color: isReady ? Colors.green : Colors.orange,
-        ),
-        const SizedBox(width: 8),
-        Expanded(child: Text('$title: $status')),
-        if (onAction != null)
-          TextButton(onPressed: onAction, child: Text(actionLabel)),
-      ],
+  Widget _compactActionButton(
+    BuildContext context, {
+    required String label,
+    required VoidCallback onPressed,
+  }) {
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        minimumSize: const Size(0, 0),
+        visualDensity: VisualDensity.compact,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Text(label, style: Theme.of(context).textTheme.bodySmall),
     );
   }
 }
@@ -260,15 +219,11 @@ class _ScanStatusIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(
-          isScanning ? Icons.wifi_tethering : Icons.wifi_tethering_off,
-          color: isScanning ? Colors.green : Colors.grey,
-        ),
-        const SizedBox(width: 6),
-        Text(isScanning ? 'Scanning' : 'Idle'),
-      ],
+    final label = isScanning ? 'Scanning' : 'Idle';
+    return Chip(
+      label: Text(label),
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
     );
   }
 }
@@ -294,24 +249,40 @@ class _DeviceList extends StatelessWidget {
       return const Center(child: Text('No Naviga devices found yet.'));
     }
 
+    final ordered = List<NavigaScanDevice>.from(devices);
+    if (connectedDeviceId != null) {
+      final index = ordered.indexWhere(
+        (device) => device.id == connectedDeviceId,
+      );
+      if (index > 0) {
+        final connected = ordered.removeAt(index);
+        ordered.insert(0, connected);
+      }
+    }
+
     return ListView.separated(
-      padding: const EdgeInsets.all(16),
-      itemCount: devices.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 12),
+      padding: const EdgeInsets.all(12),
+      itemCount: ordered.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 8),
       itemBuilder: (context, index) {
-        final device = devices[index];
+        final device = ordered[index];
+        final isConnected = _isConnected(device);
         final lastSeenSeconds = DateTime.now()
             .difference(device.lastSeen)
             .inSeconds;
 
         return Card(
+          color: isConnected
+              ? Theme.of(context).colorScheme.primary.withAlpha(15)
+              : null,
           child: ListTile(
-            title: Text(device.name),
-            subtitle: Text(
-              'ID: ${device.id}\nRSSI: ${device.rssi} dBm · '
-              'last seen ${lastSeenSeconds}s ago',
+            dense: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 4,
             ),
-            isThreeLine: true,
+            title: Text('${device.name} • ID:${_shortId(device.id)}'),
+            subtitle: Text('RSSI ${device.rssi} dBm • ${lastSeenSeconds}s ago'),
             onTap: () => _handleDeviceTap(context, device),
             trailing: _trailingIcon(device),
           ),
@@ -329,9 +300,7 @@ class _DeviceList extends StatelessWidget {
       return;
     }
 
-    final isConnected =
-        connectedDeviceId == device.id &&
-        connectionStatus == ConnectionStatus.connected;
+    final isConnected = _isConnected(device);
     if (isConnected) {
       onDisconnect();
     } else {
@@ -340,11 +309,12 @@ class _DeviceList extends StatelessWidget {
   }
 
   Widget _trailingIcon(NavigaScanDevice device) {
-    final isConnected =
-        connectedDeviceId == device.id &&
-        connectionStatus == ConnectionStatus.connected;
+    final isConnected = _isConnected(device);
     if (isConnected) {
-      return const Icon(Icons.link, color: Colors.green);
+      return TextButton(
+        onPressed: onDisconnect,
+        child: const Text('Disconnect'),
+      );
     }
     if (connectionStatus == ConnectionStatus.connecting &&
         connectedDeviceId == device.id) {
@@ -356,208 +326,16 @@ class _DeviceList extends StatelessWidget {
     }
     return const Icon(Icons.chevron_right);
   }
-}
 
-class _ConnectionCard extends StatelessWidget {
-  const _ConnectionCard({
-    required this.status,
-    required this.connectedDeviceId,
-    required this.lastConnectedDeviceId,
-    required this.onDisconnect,
-  });
-
-  final ConnectionStatus status;
-  final String? connectedDeviceId;
-  final String? lastConnectedDeviceId;
-  final VoidCallback onDisconnect;
-
-  @override
-  Widget build(BuildContext context) {
-    final statusLabel = switch (status) {
-      ConnectionStatus.idle => 'Idle',
-      ConnectionStatus.connecting => 'Connecting…',
-      ConnectionStatus.connected => 'Connected',
-      ConnectionStatus.disconnecting => 'Disconnecting…',
-      ConnectionStatus.failed => 'Failed',
-    };
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Connection', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text('Status: $statusLabel'),
-            if (connectedDeviceId != null)
-              Text('Connected: $connectedDeviceId'),
-            if (connectedDeviceId == null && lastConnectedDeviceId != null)
-              Text('Last device: $lastConnectedDeviceId'),
-            if (status == ConnectionStatus.connected)
-              Align(
-                alignment: Alignment.centerRight,
-                child: TextButton(
-                  onPressed: onDisconnect,
-                  child: const Text('Disconnect'),
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _TelemetryCard extends StatelessWidget {
-  const _TelemetryCard({required this.state});
-
-  final ConnectState state;
-
-  @override
-  Widget build(BuildContext context) {
-    final deviceInfo = state.deviceInfo;
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Telemetry', style: Theme.of(context).textTheme.titleMedium),
-            if (state.isDiscoveringServices) ...[
-              const SizedBox(height: 8),
-              const Text('Discovering services…'),
-            ],
-            if (state.telemetryError != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                state.telemetryError!,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(color: Colors.redAccent),
-              ),
-            ],
-            if (deviceInfo != null) ...[
-              const SizedBox(height: 12),
-              Text('DeviceInfo', style: Theme.of(context).textTheme.titleSmall),
-              const SizedBox(height: 6),
-              _TelemetryRow(
-                label: 'Format',
-                value:
-                    '${deviceInfo.formatVer} (BLE ${deviceInfo.bleSchemaVer})',
-              ),
-              _TelemetryRow(
-                label: 'Node ID',
-                value: _formatHex(deviceInfo.nodeId, digits: 16),
-              ),
-              _TelemetryRow(
-                label: 'Short ID',
-                value: _formatHex(deviceInfo.shortId, digits: 4),
-              ),
-              _TelemetryRow(
-                label: 'Firmware',
-                value: deviceInfo.firmwareVersion ?? '—',
-              ),
-              _TelemetryRow(
-                label: 'Radio module',
-                value: deviceInfo.radioModuleModel ?? '—',
-              ),
-              _TelemetryRow(
-                label: 'Band',
-                value: _formatInt(deviceInfo.bandId),
-              ),
-              _TelemetryRow(
-                label: 'Power',
-                value: _formatRange(deviceInfo.powerMin, deviceInfo.powerMax),
-              ),
-              _TelemetryRow(
-                label: 'Channel range',
-                value: _formatRange(
-                  deviceInfo.channelMin,
-                  deviceInfo.channelMax,
-                ),
-              ),
-              _TelemetryRow(
-                label: 'Network mode',
-                value: _formatInt(deviceInfo.networkMode),
-              ),
-              _TelemetryRow(
-                label: 'Channel ID',
-                value: _formatInt(deviceInfo.channelId),
-              ),
-              _TelemetryRow(
-                label: 'Capabilities',
-                value: _formatHex(deviceInfo.capabilities, digits: 8),
-              ),
-              if (state.deviceInfoWarning != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: Text(
-                    state.deviceInfoWarning!,
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodySmall?.copyWith(color: Colors.orange),
-                  ),
-                ),
-            ],
-            if (deviceInfo == null &&
-                !state.isDiscoveringServices &&
-                state.telemetryError == null)
-              const Padding(
-                padding: EdgeInsets.only(top: 8),
-                child: Text('No telemetry available yet.'),
-              ),
-          ],
-        ),
-      ),
-    );
+  bool _isConnected(NavigaScanDevice device) {
+    return connectedDeviceId == device.id &&
+        connectionStatus == ConnectionStatus.connected;
   }
 
-  String _formatInt(int? value, {String? unit}) {
-    if (value == null) {
-      return '—';
+  String _shortId(String id) {
+    if (id.length <= 4) {
+      return id.toUpperCase();
     }
-    if (unit == null) {
-      return '$value';
-    }
-    return '$value $unit';
-  }
-
-  String _formatRange(int? min, int? max) {
-    if (min == null || max == null) {
-      return '—';
-    }
-    return '$min–$max';
-  }
-
-  String _formatHex(int? value, {required int digits}) {
-    if (value == null) {
-      return '—';
-    }
-    return value.toRadixString(16).padLeft(digits, '0').toUpperCase();
-  }
-}
-
-class _TelemetryRow extends StatelessWidget {
-  const _TelemetryRow({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 4),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 110,
-            child: Text(label, style: Theme.of(context).textTheme.bodySmall),
-          ),
-          Expanded(child: Text(value)),
-        ],
-      ),
-    );
+    return id.substring(id.length - 4).toUpperCase();
   }
 }


### PR DESCRIPTION
## Summary
- Remove Telemetry UI and connection panel from Connect
- Compact readiness summary with inline CTAs
- Tightened scan controls and device cards; connected device pinned, highlighted, and shows Disconnect

## Test plan
- [x] cd app && dart format .
- [x] cd app && flutter analyze
- [x] cd app && flutter test
- [ ] Samsung S8: idle scanning shows list with plenty of space
- [ ] Samsung S8: tap device → scan stops, card moves to top + highlighted + Disconnect appears
- [ ] Samsung S8: no transient panels, no overflow warning


Made with [Cursor](https://cursor.com)