### PR TITLE
docs: enforce branch-per-issue PR discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Claude Code Instructions (Naviga)
+
+## Role
+You are used as a THINKING and ARCHITECTURE model.
+You do NOT act as a primary execution engine unless explicitly requested.
+
+## Primary Responsibilities
+- System architecture
+- Protocol design
+- Long-lived invariants
+- Domain boundaries
+- ADRs and technical documentation
+- Reviewing plans before execution
+
+## Forbidden Actions (unless explicitly asked)
+- Making bulk code changes
+- Refactoring without an approved plan
+- Touching runtime wiring (M1Runtime) without a step-by-step plan
+- Mixing refactor + behavior change in one step
+
+## When to Stop
+If a task requires:
+- mechanical code edits
+- multi-file execution
+- implementation work
+
+You must STOP and request handoff to an execution model.
+
+## Naviga-specific Critical Zones
+- firmware/domain/*
+- NodeTable logic
+- Protocol definitions
+- JOIN / Mesh specs
+
+Changes here require explicit confirmation.
+
+## PR / Branch discipline (default)
+
+Unless explicitly stated otherwise:
+
+- **One issue = one branch = one PR.**
+- Always create the branch from **up-to-date `main`**.
+- Branch name: `issue/<number>-<short-slug>` (or project convention).
+- A PR must contain changes relevant to **that single issue only**.
+- **Never mix** docs + firmware/app (or multiple issues) in the same PR.
+
+### Pre-PR sanity check (mandatory)
+Before opening a PR, run:
+- `git log --oneline main..HEAD` (must show only intended commits)
+- `git diff --stat main..HEAD` (must show only intended files/areas)
+
+If unrelated commits/files are present: **STOP**. Recreate the branch from `main` and re-apply only the intended changes.
+
+This prevents mixed PRs like #136 that caused docs/firmware cross-contamination and expensive cleanup.


### PR DESCRIPTION
## Summary
Add an explicit PR/branch discipline rule so that AI assistants and humans default to "one issue = one branch = one PR" and avoid mixed PRs like #136.

## Details
- Updated  with a new section **"PR / Branch discipline (default)"**:
  - One issue = one branch = one PR.
  - Branches must be created from up-to-date .
  - PRs must only contain changes relevant to that single issue.
  - Never mix docs with firmware/app (or multiple issues) in the same PR.
  - Mandatory pre-PR sanity checks: 1fd5c2a docs: enforce branch-per-issue PR discipline and  CLAUDE.md | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 54 insertions(+).
  - If unrelated commits/files appear, stop and recreate the branch from .
- Added a short rationale line: this prevents mixed PRs like #136 that caused docs/firmware cross-contamination and expensive cleanup.

## Scope
- Docs-only change in .
- No code, firmware, or app changes.


Made with [Cursor](https://cursor.com)