### PR TITLE
Docs: canonical docs set (PR2 of #119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Naviga/
 └── README.md
 ```
 
-Documentation: [docs/](docs/) — structure and plans in [docs/CLEAN_SLATE.md](docs/CLEAN_SLATE.md), [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md).
+Documentation: **Start here → [docs/START_HERE.md](docs/START_HERE.md)**. See also [docs/CLEAN_SLATE.md](docs/CLEAN_SLATE.md).
 
 ## 🛠️ Technology Stack
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,21 @@
+# Naviga — Start here
+
+**Naviga** is an autonomous outdoor navigation and communication system: embedded firmware (ESP32 + LoRa) + BLE bridge + mobile app. Offline-first; mesh and JOIN are future.
+
+## What works now (OOTB v1)
+
+- **Firmware:** GEO_BEACON TX/RX, NodeTable, BLE NodeTableSnapshot/DeviceInfo. E220 UART LoRa as modem; M1Runtime wires domain ↔ radio ↔ BLE.
+- **Mobile (Flutter):** Connect, My Node, Nodes, Map (online tiles), Settings. BLE read-only; NodeTable cache.
+- **OOTB v1** completed 2026-02-12; issues #2–#35 closed. Evidence: [OOTB progress inventory](project/ootb_progress_inventory.md), [OOTB workmap](project/ootb_workmap.md).
+
+## How to navigate docs
+
+| Where | What |
+|-------|------|
+| **[State after OOTB v1](project/state_after_ootb_v1.md)** | Snapshot: what’s in, invariants, next steps. |
+| **[Docs map: canonical vs working](project/docs_map.md)** | Which docs are canonical, reference, or to be archived (PR3). |
+| [Architecture index](architecture/index.md) | Layer map, source-of-truth table, repo layout. |
+| [OOTB progress inventory](project/ootb_progress_inventory.md) | Per-issue PR evidence and Mobile v1 tracking. |
+| [OOTB workmap](project/ootb_workmap.md) | Plan, status table, rules. |
+
+For development workflow and PR discipline, see repo root **CLAUDE.md** and `docs/dev/` (reference only; open explicitly when needed).

--- a/docs/project/docs_map.md
+++ b/docs/project/docs_map.md
@@ -1,0 +1,25 @@
+# Docs map: canonical vs reference vs working
+
+This document categorizes docs so readers land on canon first. **PR2 (Issue #119) does not move, rename, archive, or delete any files.** PR3 will archive working artifacts into `_archive/ootb_v1/`.
+
+## Canonical (entrypoint and snapshot)
+
+- **[../START_HERE.md](../START_HERE.md)** — Entrypoint: what Naviga is, what works now, where to look next.
+- **[state_after_ootb_v1.md](state_after_ootb_v1.md)** — Snapshot after OOTB v1 (2026-02-12): scope, invariants, evidence links.
+- **This file** — Map of doc categories.
+
+## Reference (stable specs; link from canon or architecture index)
+
+- [../architecture/index.md](../architecture/index.md) — Architecture index, layer map, source-of-truth table.
+- [../adr/](../adr/) — ADRs (position source, radio band, etc.).
+- [../protocols/](../protocols/) — OOTB Radio v0, BLE v0, presets.
+- [../firmware/](../firmware/) — HAL contracts, NodeTable spec, GNSS, firmware arch.
+- [../product/](../product/) — Product core, scope, test plan, OOTB analysis (where still accurate).
+
+## Working (trail / planning; to be archived in PR3)
+
+- [ootb_progress_inventory.md](ootb_progress_inventory.md) — Per-issue PR evidence; Mobile v1 tracking.
+- [ootb_workmap.md](ootb_workmap.md) — Workmap, status table, phase rules.
+- Other `docs/dev/`, `docs/product/` planning and working docs as identified in PR3.
+
+**Archive plan:** PR3 will move working artifacts into `_archive/ootb_v1/` and update links as needed. No file moves in PR2.

--- a/docs/project/state_after_ootb_v1.md
+++ b/docs/project/state_after_ootb_v1.md
@@ -1,0 +1,30 @@
+# State after OOTB v1
+
+**Completion date:** 2026-02-12.  
+**Meaning of “OOTB v1 done”:** All planned OOTB v0 / Mobile v1 issues (#2–#35, #74, #76, #80–#90) are delivered and closed. Firmware sends/receives GEO_BEACON, maintains NodeTable, exposes data over BLE; mobile app connects, shows nodes and map. Field test 2–5 nodes done.
+
+Evidence and trail:
+
+- [OOTB progress inventory](ootb_progress_inventory.md) — per-issue PR links and Mobile v1 table.
+- [OOTB workmap](ootb_workmap.md) — plan, status table, phase rules.
+
+## Key constraints / invariants (do not violate)
+
+- **Embedded-first stack:** firmware → radio → domain → BLE bridge → mobile.
+- **Hardware:** ESP32 + E220 UART LoRa modules used as **MODEMs** (not chip-level drivers). E220Radio = IRadio adapter.
+- **CAD/LBT:** Out of scope. Channel-sense abstraction exists; E220 returns UNSUPPORTED. Default = jitter-only, sense OFF.
+- **Domain:** NodeTable and BeaconLogic are **radio-agnostic** (no radio types in domain).
+- **Wiring:** **M1Runtime** is the single composition point (GEO_BEACON ↔ NodeTable ↔ BLE).
+- **Legacy BLE service:** Remains **disabled** unless explicitly reintroduced by plan.
+
+## Explicitly out of scope (OOTB v1)
+
+- JOIN, Session Master, anchor roles.
+- Mesh (covered_mask, best_mask, relays).
+- Real CAD/LBT; SPI radio driver; offline maps in v0.
+- BLE write/config in mobile v1.
+
+## Next known follow-ups
+
+- **Issue #135:** Docs archive/cleanup (working docs → `_archive/ootb_v1/`). **PR3** of [#119](https://github.com/AlexanderTsarkov/naviga-app/issues/119) will perform the archive; this PR (PR2) does not move or delete files.
+- JOIN/Mesh: future; see product specs when needed.


### PR DESCRIPTION
Refs #119 (does not close; PR3 will do archive/cleanup).

## Summary
Add minimal canonical doc set: entrypoint (Start here), snapshot (State after OOTB v1), and docs map (canonical vs reference vs working). One pointer in root README so readers land on canon first.

## Scope
- **Included:** New `docs/START_HERE.md`, `docs/project/state_after_ootb_v1.md`, `docs/project/docs_map.md`; one-line doc link in `README.md`.
- **Excluded:** No file moves/renames/archives/deletes (PR3); no code changes.

## How to verify
1. Open [docs/START_HERE.md](docs/START_HERE.md) — entrypoint with links to State snapshot and Docs map.
2. Open [docs/project/state_after_ootb_v1.md](docs/project/state_after_ootb_v1.md) — invariants and evidence links.
3. Open [docs/project/docs_map.md](docs/project/docs_map.md) — categories and PR3 archive note.
4. Root README: “Start here → docs/START_HERE.md”.