### PR TITLE
Docs: allow push + gh pr create as default completion; forbid force-w…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ If a task requires:
 
 You must STOP and request handoff to an execution model.
 
+### Default PR mechanics (allowed)
+After completing a task, you may:
+- **Allowed:** `git push -u origin <branch>` and create a PR via `gh pr create` (when `gh` is configured).
+- **Not allowed:** merge, close PR, or press the merge button — request handoff for those.
+- **If push would require `--force-with-lease`** (e.g. after rebase or rewritten history): **STOP** and request handoff or explicit approval; do not force-push without confirmation.
+
 ## Naviga-specific Critical Zones
 - firmware/domain/*
 - NodeTable logic


### PR DESCRIPTION
## Summary
Narrow exception in CLAUDE.md: after completing a task, Cursor may push the current branch and open a PR with `gh pr create`. Merge/close remain handoff-only.

## Change
- New subsection **Default PR mechanics (allowed)** under "When to Stop":
  - Allowed: `git push -u origin <branch>`, `gh pr create`.
  - Not allowed: merge, close PR, merge button.
  - **Force-with-lease guard:** If push would require `--force-with-lease` (e.g. after rebase), STOP and request handoff or explicit approval; no force-push without confirmation.

## Why
Makes push + PR creation the default completion step without relaxing "not an execution engine" or "never mix docs + firmware/app". Avoids accidental force-push after rebase.

## How to verify
Open CLAUDE.md → find "Default PR mechanics (allowed)" after "When to Stop"; confirm allowed vs not allowed and the force-with-lease rule.