### PR TITLE
Docs: add ITERATION.md and research artifacts policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ After completing a task, you may:
 
 Changes here require explicit confirmation.
 
+## Research artifacts policy
+
+- **Research outputs** (investigations, spikes, issue research notes) go to **`_working/research/`**, not under `docs/**`.
+- **End-of-iteration archive:** move `_working/research/` contents to **`_archive/iterations/<ITERATION_ID>/research/`**.  
+  **`<ITERATION_ID>`** MUST be read from **`_working/ITERATION.md`** (exactly one line).  
+  If `_working/ITERATION.md` is missing or empty: **STOP** and ask for the iteration id; do not invent one.
+
 ## PR / Branch discipline (default)
 
 Unless explicitly stated otherwise:

--- a/_working/ITERATION.md
+++ b/_working/ITERATION.md
@@ -1,0 +1,1 @@
+S01__2026-02__OOTB.v1_consolidation_cleanup


### PR DESCRIPTION
## Summary
- **Single source of truth for iteration:** `_working/ITERATION.md` with one line: `S01__2026-02__OOTB.v1_consolidation_cleanup`.
- **CLAUDE.md — Research artifacts policy:** research outputs go to `_working/research/` (not `docs/**`); end-of-iteration archive is `_archive/iterations/<ITERATION_ID>/research/` with `ITERATION_ID` read from `_working/ITERATION.md`; if that file is missing/empty, STOP and ask (do not invent).

## How to verify
- `_working/ITERATION.md` exists and contains exactly the iteration id line.
- CLAUDE.md has a "Research artifacts policy" section; it mandates reading from ITERATION.md and forbids guessing.


Made with [Cursor](https://cursor.com)