### PR TITLE
docs: scaffold NodeTable WIP docs (#147)

### DIFF
--- a/docs/product/wip/areas/nodetable/index.md
+++ b/docs/product/wip/areas/nodetable/index.md
@@ -1,8 +1,64 @@
-# WIP: NodeTable / identity / discovery
+# WIP: NodeTable — Define & Research
 
-- **Problem / constraints:** *(fill in)*
-- **Options:** *(fill in)*
-- **Current leaning:** *(fill in)*
-- **Promotion criteria:** Ready when decision is summarized in [../../../areas/nodetable.md](../../../areas/nodetable.md).
+Scaffolding for [Issue #147](https://github.com/AlexanderTsarkov/naviga-app/issues/147). No promotion to canon yet.
 
-Research: [research/](research/).
+---
+
+## Definition
+
+<!-- TODO: Short, strict product definition of NodeTable in Naviga -->
+
+---
+
+## Responsibilities (in-scope)
+
+<!-- TODO: What NodeTable is responsible for -->
+
+---
+
+## Non-goals
+
+<!-- TODO: Explicit out-of-scope -->
+
+---
+
+## Data sources (Firmware/Radio/Domain/BLE/Mobile touchpoints)
+
+<!-- TODO: Where data feeding NodeTable comes from -->
+
+---
+
+## Core semantic model (fields/identifiers) — WIP
+
+<!-- TODO: Fields, identifiers, minimal schema -->
+
+---
+
+## Status / Activity model (TTL, last heard, confidence) — WIP
+
+<!-- TODO: TTL, last-heard, confidence semantics -->
+
+---
+
+## UX / product decisions powered by NodeTable
+
+<!-- TODO: Which product/UX decisions depend on NodeTable -->
+
+---
+
+## Open questions
+
+<!-- TODO: Unresolved decisions, trade-offs -->
+
+---
+
+## Promotion criteria (WIP → canon)
+
+<!-- TODO: When this WIP can be promoted to docs/product/areas/nodetable.md -->
+
+---
+
+## Links / References
+
+- Research: [research/](research/)
+- Issue: [#147 NodeTable — Define & Research (Product WIP)](https://github.com/AlexanderTsarkov/naviga-app/issues/147)

--- a/docs/product/wip/areas/nodetable/research/meshastic-nodetable.md
+++ b/docs/product/wip/areas/nodetable/research/meshastic-nodetable.md
@@ -1,0 +1,51 @@
+# Research: Meshtastic NodeDB / NodeTable
+
+Placeholder for Meshtastic node-database research. No deep research yet — fill in per Issue #147.
+
+---
+
+## Scope
+
+<!-- TODO: What this research covers (NodeDB, NodeInfo, activity, updates) -->
+
+---
+
+## Version / commit / date (TODO)
+
+<!-- TODO: Exact Meshtastic version/commit and date of research -->
+
+---
+
+## NodeDB / NodeInfo model (fields) (TODO)
+
+<!-- TODO: List fields, types, semantics -->
+
+---
+
+## Activity / TTL / last-heard semantics (TODO)
+
+<!-- TODO: How Meshtastic models activity, TTL, last-heard -->
+
+---
+
+## Update sources (packet types: user/position/telemetry/etc.) (TODO)
+
+<!-- TODO: Which packet types update the node DB, sources of truth -->
+
+---
+
+## Decisions derived from fields (TODO)
+
+<!-- TODO: What logic/UX decisions Meshtastic bases on node fields -->
+
+---
+
+## Notes relevant to Naviga (candidate transfers / non-transfers) (TODO)
+
+<!-- TODO: What to adopt vs not adopt for Naviga -->
+
+---
+
+## Sources (links) (TODO)
+
+<!-- TODO: Links to Meshtastic docs, code, commits -->

--- a/docs/product/wip/areas/nodetable/research/naviga-current-state.md
+++ b/docs/product/wip/areas/nodetable/research/naviga-current-state.md
@@ -1,0 +1,39 @@
+# Research: Naviga NodeTable — current state
+
+Placeholder for documenting current NodeTable implementation in Naviga. No deep research yet — fill in per Issue #147.
+
+---
+
+## Scope
+
+<!-- TODO: What this doc covers (location, fields, usage) -->
+
+---
+
+## Where NodeTable lives (paths) (TODO)
+
+<!-- TODO: Modules/files where NodeTable is defined and used -->
+
+---
+
+## Current fields/statuses (TODO)
+
+<!-- TODO: List current fields and status types -->
+
+---
+
+## Used vs dead fields (TODO)
+
+<!-- TODO: Which fields are used by logic/UX vs legacy/unused -->
+
+---
+
+## Call sites (logic/UX) (TODO)
+
+<!-- TODO: Where NodeTable is read or updated (logic and UX) -->
+
+---
+
+## Notes / gaps
+
+<!-- TODO: Known gaps, assumptions, follow-ups -->


### PR DESCRIPTION
Adds WIP doc scaffolding for **NodeTable — Define & Research**.

Relates to #147 (scaffolding only; no deep research yet).

**Changes:**
- `docs/product/wip/areas/nodetable/index.md` — section templates + TODOs (Definition, Responsibilities, Data sources, Core model, Status/Activity, UX decisions, Open questions, Promotion criteria, Links)
- `docs/product/wip/areas/nodetable/research/meshastic-nodetable.md` — Meshtastic research placeholder (version/commit, NodeDB fields, TTL/activity, update sources, decisions, sources)
- `docs/product/wip/areas/nodetable/research/naviga-current-state.md` — Naviga current-state placeholder (paths, fields, used vs dead, call sites)

**Scope:** Docs only; no firmware/mobile code changes. No promotion to canon.

Made with [Cursor](https://cursor.com)