### PR TITLE
docs: AI model policy (OOTB not product truth) + CLAUDE always-on invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 You are used as a THINKING and ARCHITECTURE model.
 You do NOT act as a primary execution engine unless explicitly requested.
 
+### Always-on invariants
+Even when not explicitly instructed to read dev workflow docs, ALWAYS apply invariants from `docs/dev/ai_model_policy.md`.
+- **`docs/dev/ai_model_policy.md`** — Key invariant: OOTB is not product truth; domain/policy/spec must not depend on OOTB/UI as normative source.
+
 ## Primary Responsibilities
 - System architecture
 - Protocol design

--- a/docs/dev/ai_model_policy.md
+++ b/docs/dev/ai_model_policy.md
@@ -1,0 +1,9 @@
+# AI model policy — invariants and review blockers
+
+Canonical rule for product/domain/spec work:
+
+**OOTB is not product truth.** Domain, policy, and spec docs must not depend on OOTB or UI as normative source. OOTB and UI may be referenced as examples or defaults only when explicitly marked non-normative.
+
+## Review blocker
+
+Reviews **MUST** block merge if product, domain, or spec documentation treats OOTB or UI as the normative source of truth (e.g. defining staleness, retention, or precedence by OOTB/UI thresholds without deferring the boundary to policy or consumer).

--- a/docs/dev/ai_workflow_cursor_chatgpt.md
+++ b/docs/dev/ai_workflow_cursor_chatgpt.md
@@ -107,3 +107,5 @@ Rule of thumb:
 - Real CAD/LBT is out of scope unless explicitly planned.
 - Domain (NodeTable/BeaconLogic) must stay radio-agnostic.
 - Legacy BLE service must remain disabled unless explicitly reintroduced by plan.
+
+**See also:** [AI model policy](ai_model_policy.md) (invariants and review blockers).


### PR DESCRIPTION
Docs-only: dev workflow and model policy.

- **New** `docs/dev/ai_model_policy.md`: canonical rule "OOTB is not product truth" and review-blocker wording.
- **Edit** `docs/dev/ai_workflow_cursor_chatgpt.md`: minimal cross-reference to `ai_model_policy.md`.
- **Edit** `CLAUDE.md`: Always-on invariants subsection pointing to `ai_model_policy.md` so invariants apply even when not explicitly instructed to read dev docs.

No code or product doc changes. CI: lint only (docs).

Made with [Cursor](https://cursor.com)