### PR TITLE
docs: OOTB profiles — add scope note (non-normative consumer policy)

### DIFF
--- a/docs/product/wip/areas/nodetable/policy/ootb-profiles-v0.md
+++ b/docs/product/wip/areas/nodetable/policy/ootb-profiles-v0.md
@@ -4,6 +4,8 @@
 
 Step 1: Draft the OOTB profiles table and derivation rules. Distance granularity comes first; time between beacons is derived via **speedHint** (typical speed for the subject/role).
 
+**Scope / Non-normative note.** This document describes **one OOTB consumer policy** for activity interpretation and staleness-boundary examples. It is **not** normative product truth for domain semantics. Domain, policy, and spec consume a **policy-supplied boundary** and do not depend on this doc as the only source.
+
 ---
 
 ## 1) Derivation formulas (v0)


### PR DESCRIPTION
Context: [#155](https://github.com/AlexanderTsarkov/naviga-app/issues/155). **Layering invariant:** OOTB is not product truth ([docs/dev/ai_model_policy.md](docs/dev/ai_model_policy.md)).

**Change (docs-only, framing only):**
- Add a short **Scope / Non-normative note** near the top of `ootb-profiles-v0.md`: this doc describes one OOTB consumer policy for activity interpretation / staleness-boundary examples; it is **not** normative product truth for domain semantics; domain/policy/spec consume a policy-supplied boundary and do not depend on this doc as the only source.

No tables, formulas, or thresholds changed. CI: lint only.

Made with [Cursor](https://cursor.com)