### PR TITLE
docs: SelectionPolicy v0 — profile/channel defaults, throttling, user advice (#147)

### DIFF
--- a/docs/product/wip/areas/nodetable/index.md
+++ b/docs/product/wip/areas/nodetable/index.md
@@ -145,7 +145,7 @@ Activity expectations are derived from **roles + distance granularity + speed hi
 ## Status (registries #159)
 
 - **Decisions captured (v0):** HW Capabilities registry (hw_profile_id, adapter_type, capability, confidence; local vs remote disclosure; schema rev, unknown hw id → prompt for update) and RadioProfiles + ChannelPlan registry (user abstraction Default/LongDist/Fast; profile–channel compatibility; registries = facts, SelectionPolicy = choice rules; non-goals: no raw LoRa UI, no real CAD/LBT here, sense OFF + jitter default for UART).
-- **Follow-up issues / docs needed:** SelectionPolicy (choice rules, autopower, throttling, defaults); autopower algorithm; identity/pairing flow and use of local vs remote disclosure; registry ownership and format (firmware vs mobile vs backend).
+- **Follow-up issues / docs needed:** Autopower algorithm; identity/pairing flow and use of local vs remote disclosure; registry ownership and format (firmware vs mobile vs backend). SelectionPolicy v0 is documented in [../radio/selection_policy_v0.md](../radio/selection_policy_v0.md).
 
 ---
 
@@ -182,4 +182,5 @@ When decisions above are stable and reflected in implementation, promote to `doc
 - Contract: [contract/link-telemetry-minset-v0.md](contract/link-telemetry-minset-v0.md) (Link/Metrics & Telemetry/Health minset v0, [#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158)).
 - Registry: [../hardware/registry_hw_capabilities_v0.md](../hardware/registry_hw_capabilities_v0.md) (HW Capabilities registry v0, [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159)).
 - Registry: [../radio/registry_radio_profiles_v0.md](../radio/registry_radio_profiles_v0.md) (RadioProfiles & ChannelPlan registry v0, [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159)).
+- Policy: [../radio/selection_policy_v0.md](../radio/selection_policy_v0.md) (Radio profile/channel selection & throttling v0; consumes [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159), [#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158)).
 - Issue: [#147 NodeTable — Define & Research (Product WIP)](https://github.com/AlexanderTsarkov/naviga-app/issues/147)

--- a/docs/product/wip/areas/radio/registry_radio_profiles_v0.md
+++ b/docs/product/wip/areas/radio/registry_radio_profiles_v0.md
@@ -24,6 +24,7 @@ This doc defines the **RadioProfiles** and **ChannelPlan** registry v0: user-fac
 ## 3) Relation to ChannelPlan: compatibility
 
 - **ChannelPlan** defines channels (e.g. frequency, regulatory region). Each channel (or channel range) can be **tagged** with **compatible RadioProfile(s)**.
+- **What “compatible” means:** A **compatible channel** for a profile is one where nodes on that channel are expected to use mutually decodable air-parameter families for that profile. Different RadioProfiles may use different air-parameter families; therefore they must not share the same channel range by default, to avoid mutual interference and non-visibility.
 - **Switching profile implies channel compatibility:** When the user switches to a given RadioProfile, the valid channel set is **those channels tagged as compatible with that profile**. If the current channel is not compatible with the new profile, the device/app should switch to a compatible channel (or prompt); exact UX is out of scope here.
 - **Registries contain facts:** The RadioProfile registry lists profiles and their semantics (e.g. “LongDist = better range, lower rate”); the ChannelPlan registry (or combined table) lists channels and which profile(s) they support. **SelectionPolicy** (future doc/issue) defines **which** profile/channel to choose under which conditions (autopower, throttling, defaults).
 
@@ -32,7 +33,8 @@ This doc defines the **RadioProfiles** and **ChannelPlan** registry v0: user-fac
 ## 4) Policy boundary
 
 - **Registries:** Contain **facts** — which profiles exist, which channels exist, which profile–channel pairs are valid. No “when to switch” or “default for first boot” here.
-- **SelectionPolicy (future):** Contains **choice rules** — autopower algorithm, throttling under load, default profile/channel for OOTB or after factory reset. Referenced as a follow-up; not defined in this doc.
+- **SelectionPolicy:** Contains **choice rules** — default profile/channel, throttling under load, user-facing effects/advice. See [selection_policy_v0.md](selection_policy_v0.md). Autopower algorithm remains a separate follow-up.
+- **v0 baseline policy:** UART track baseline: channel sense is OFF; collision mitigation via jitter-only. Any “utilization” is an estimate with low confidence.
 
 ---
 
@@ -46,7 +48,7 @@ This doc defines the **RadioProfiles** and **ChannelPlan** registry v0: user-fac
 
 ## 6) Open questions / follow-ups
 
-- **SelectionPolicy:** Separate doc/issue for choice rules (autopower, throttling, default profile/channel).
+- **SelectionPolicy:** Choice rules (defaults, throttling, user advice) are in [selection_policy_v0.md](selection_policy_v0.md). Autopower algorithm remains a separate follow-up.
 - **Autopower algorithm:** How tx power or profile is adapted from environment/capabilities; out of scope here.
 - **Channel discovery:** See [policy/channel-discovery-selection-v0.md](policy/channel-discovery-selection-v0.md) ([#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175)) for local scan and future backend heatmap; registry defines compatibility, not discovery flow.
 - **Beacon minset & encoding:** Payload and airtime (e.g. [#173](https://github.com/AlexanderTsarkov/naviga-app/issues/173)) are separate; this registry does not define packet format.

--- a/docs/product/wip/areas/radio/selection_policy_v0.md
+++ b/docs/product/wip/areas/radio/selection_policy_v0.md
@@ -1,0 +1,97 @@
+# Radio — SelectionPolicy v0 (Policy WIP)
+
+**Work Area:** Product Specs WIP · **Parent:** [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147) · **Consumes:** [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159) (registries), [#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158) (link/telemetry minset)
+
+This policy defines **choice rules** for RadioProfile and ChannelPlan selection, throttling under load, and user-facing effects/advice. It **consumes** registries (facts) from [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159) and NodeTable/link-telemetry signals from [#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158). No firmware or app code changes; no semantics defined via OOTB — OOTB may be referenced only as an example/indicator.
+
+---
+
+## 1) Purpose / scope
+
+- **Purpose:** Specify how the system chooses **default** RadioProfile and ChannelPlan, applies **throttling** when the channel is under load (without CAD/LBT), and surfaces **user-facing messaging** as effects and advice (not raw utilization numbers).
+- **Boundary:** **Registries = facts** (what profiles/channels exist, what is compatible); **SelectionPolicy = rules** (which to choose, when to throttle, what to show the user). This doc defines the rules only; it does not redefine registry content.
+- **Scope (v0):** Default selection; throttling behavior (jitter-only baseline); user warnings/events and suggested UI message text. Out of scope: autopower algorithm detail, Mesh semantics, raw LoRa parameter UI.
+
+---
+
+## 2) Definitions
+
+| Term | Meaning |
+|------|--------|
+| **RadioProfile** | User-facing profile (Default / LongDist / Fast) from [registry_radio_profiles_v0](registry_radio_profiles_v0.md). Choice is constrained by HW capabilities and ChannelPlan compatibility. |
+| **ChannelPlan** | Set of channels (or channel ranges) with compatibility tags per profile; from [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159) registries. |
+| **Throttling** | Reducing effective beacon cadence or deferring sends when the policy infers “channel busy.” v0: no CAD/LBT; mitigation is **jitter-only** (see guardrails). |
+| **Utilization (estimate)** | Policy-internal signal derived from NodeTable/link metrics (e.g. rxRate, observed activity). **Low confidence** on UART track; used only to drive triggers, not shown as raw numbers to the user. |
+| **Effects & advice** | User-visible outcomes: chosen profile/channel, throttling state, and **short messages** (e.g. “Channel busy — sending less often”) instead of numeric utilization. |
+
+---
+
+## 3) Inputs
+
+SelectionPolicy consumes:
+
+- **Registries ([#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159)):** HW Capabilities ([registry_hw_capabilities_v0](../hardware/registry_hw_capabilities_v0.md)), RadioProfiles & ChannelPlan ([registry_radio_profiles_v0](registry_radio_profiles_v0.md)). Used to know valid profile/channel pairs and HW limits (e.g. which profiles this device supports).
+- **NodeTable / link-telemetry minset ([#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158)):** Signals such as lastRxAt, rxRate (if present), rssiLast/snrLast, and derived linkQuality or activity. Used to infer “channel busy” or “many nodes active” for throttling triggers. No raw utilization value is exposed to the user; policy maps signals to **discrete states** and **advice**.
+- **Device state:** Current profile, current channel, relationship (e.g. Owned vs Seen), and whether Mesh is enabled (for “Fast requires Mesh” constraint).
+
+---
+
+## 4) Outputs
+
+- **Chosen profile and channel:** Default for first boot / OOTB and after factory reset; and valid transitions when the user or policy changes selection (respecting profile–channel compatibility from registries).
+- **Throttling state:** Whether the policy is currently applying extra backoff/jitter (e.g. “throttling active” vs “normal”).
+- **User-facing events / advice:** Short, non-technical messages for the UI (see table below). No raw utilization percentages or SF/BW/CR.
+
+---
+
+## 5) Guardrails (v0 baseline)
+
+- **UART track:** Channel sense is **OFF**; collision mitigation is **jitter-only**. Any “utilization” or “channel busy” is an **estimate with low confidence**; policy and UI must not present it as a precise metric.
+- **SPI/adapter_type:** If the registry marks higher confidence for utilization or sense for a given **adapter_type** (e.g. SPI_CHIP), future policy may differentiate; v0 treats all as **low confidence** for utilization and jitter-only for mitigation.
+- **Fast profile:** Documented constraint only: “Fast requires Mesh.” Policy may offer Fast only when Mesh is available/enabled; no Mesh semantics are defined in this doc.
+
+---
+
+## 6) Trigger → Action → User impact → UI message
+
+Policy maps **triggers** (from inputs) to **actions** and **user-visible effects**. UI should show **effects & advice**, not raw numbers.
+
+| Trigger | Action | User impact | UI message (example) |
+|--------|--------|--------------|------------------------|
+| First boot / factory reset | Select default profile and a compatible default channel from registries. | User gets a working profile/channel without configuration. | (None required; or “Using Default profile.”) |
+| User selects a new RadioProfile | Resolve compatible channels from ChannelPlan; if current channel incompatible, switch to a compatible channel or prompt. | Profile and channel stay consistent; no invalid combinations. | “Switched to LongDist. Channel updated for compatibility.” |
+| Inferred “channel busy” (e.g. rxRate or activity above policy threshold) | Increase jitter / backoff; reduce effective beacon cadence within allowed range. | Fewer collisions; possibly slightly less frequent updates. | “Channel busy — sending less often to avoid interference.” |
+| Inferred “channel busy” clears | Restore normal cadence/jitter. | Normal update rate. | (None, or “Sending at normal rate.”) |
+| User selects Fast but Mesh not enabled | Do not apply Fast; keep current profile or prompt to enable Mesh. | Fast not used until Mesh available. | “Fast profile requires Mesh. Enable Mesh or choose another profile.” |
+| Unknown hw_profile_id or unsupported channel in payload | Do not assume capabilities; prompt for app/registry update (per HW registry). | User is directed to update. | “Update the app to support this device.” |
+
+*Exact thresholds (e.g. “channel busy”) and message copy are product/UX decisions; this table defines the **categories** of trigger, action, and advice.*
+
+---
+
+## 7) Non-goals (v0)
+
+- No Meshtastic-like raw LoRa parameter UI (SF/BW/CR).
+- No CAD/LBT implementation; sense OFF + jitter-only remains the baseline.
+- No Mesh protocol semantics; only the product constraint “Fast requires Mesh” is documented.
+- No autopower algorithm specification (future follow-up).
+- OOTB is not normative; it may be cited as an example of default profile/channel or messaging only.
+
+---
+
+## 8) Open questions / follow-ups
+
+- **Autopower algorithm:** How to adapt tx power or profile from environment and capabilities; separate doc/issue.
+- **Exact “channel busy” thresholds:** How rxRate/activity maps to discrete states; implementation-defined with policy guidance.
+- **Default profile/channel table:** Concrete OOTB defaults (e.g. Default profile + region-specific channel) as example; not normative in this doc.
+- **Localization:** UI message strings are placeholders; final copy and localization are product/UX.
+
+---
+
+## 9) Related
+
+- **HW Capabilities registry:** [../hardware/registry_hw_capabilities_v0.md](../hardware/registry_hw_capabilities_v0.md) — [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159).
+- **RadioProfiles & ChannelPlan registry:** [registry_radio_profiles_v0.md](registry_radio_profiles_v0.md) — [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159).
+- **Link/Telemetry minset:** [../nodetable/contract/link-telemetry-minset-v0.md](../nodetable/contract/link-telemetry-minset-v0.md) — [#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158).
+- **NodeTable contract:** [../nodetable/index.md](../nodetable/index.md) — [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147).
+- **Channel discovery (stub):** [policy/channel-discovery-selection-v0.md](policy/channel-discovery-selection-v0.md) — [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175).


### PR DESCRIPTION
Ref #179

**Context:** This PR adds `docs/product/wip/areas/radio/selection_policy_v0.md` and cross-links.

## Docs-only PR (umbrella [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147))

**Follow-up from [#159](https://github.com/AlexanderTsarkov/naviga-app/issues/159) (registries):** Defines the **SelectionPolicy** that consumes registries and link-telemetry minset ([#158](https://github.com/AlexanderTsarkov/naviga-app/issues/158) / PR #172).

### Added
- **`docs/product/wip/areas/radio/selection_policy_v0.md`**
  - **Inputs:** Registries (#159), NodeTable/link-telemetry minset (#158).
  - **Outputs:** Chosen profile/channel, throttling state, user warnings/events (effects & advice, not raw utilization).
  - **Guardrails:** UART baseline sense OFF + jitter-only; utilization is low-confidence estimate.
  - **Trigger → Action → User impact → UI message** table (defaults, profile switch, channel busy, Fast requires Mesh, unknown hw).
  - Clear boundary: Registry = facts, SelectionPolicy = rules.
  - Open questions + follow-ups (autopower, thresholds, localization).

### Updated
- **`registry_radio_profiles_v0.md`** — Link to `selection_policy_v0.md`; autopower remains separate follow-up.
- **`nodetable/index.md`** — Link to SelectionPolicy v0; Status follow-ups updated.

### Quality
- No firmware or mobile code changes.
- No raw LoRa UI (SF/BW/CR); no Mesh semantics (constraint "Fast requires Mesh" only).
- OOTB referenced as example/indicator only.
- Readable in <7 min.