### PR TITLE
docs(radio): add profiles policy v0 (defaults+persistence+reset)

### DIFF
--- a/docs/product/wip/areas/radio/policy/radio_profiles_policy_v0.md
+++ b/docs/product/wip/areas/radio/policy/radio_profiles_policy_v0.md
@@ -1,0 +1,107 @@
+# Radio — Radio profiles policy v0 (defaults, persistence, factory reset)
+
+**Work Area:** Product Specs WIP · **Parent:** [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211) · **Umbrella:** [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147)
+
+This policy defines the **v0/V1-A baseline** for radio profile model, persistence semantics, first-boot behavior, and factory reset. It makes **OOTB defaults deterministic** without depending on UI or product copy as normative source. Related: [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175) (channel discovery, post V1-A), [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184) (registry bundle format).
+
+---
+
+## 1) Purpose & scope
+
+- **Purpose:** Formally define the **RadioProfile** model (parameters), **profile persistence** (default vs user, current/previous pointers), **first boot** rule, **factory reset** semantics, and a minimal **conceptual API** (list / select / reset). This is the policy that guarantees a defined boot config and deterministic OOTB behavior.
+- **Scope (v0):** Default profile (immutable); user profiles (add/remove); persisted pointers (CurrentProfileId, optional PreviousProfileId); first boot and factory reset rules; no storage or wire format — only semantics.
+- **Explicit note:** This doc is the **V0/V1-A baseline** that makes OOTB deterministic. Implementation and UI consume this policy; OOTB/UI are not the source of truth for these rules.
+
+---
+
+## 2) Non-goals (v0)
+
+- No channel discovery or channel-list source ([#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175)) in this policy; that is future/post V1-A.
+- No CAD/LBT; no mesh/JOIN semantics.
+- No backend distribution of profiles (ties to [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184)); OOTB defaults exist regardless of bundle delivery.
+- No implementation detail (storage layout, wire format); only normative semantics.
+
+---
+
+## 3) Definitions
+
+### 3.1 RadioProfile (model)
+
+A **RadioProfile** is a named set of parameters used for radio operation:
+
+| Parameter | v0 meaning | Future (out of scope here) |
+|-----------|------------|----------------------------|
+| **channel** | Logical channel identifier (source and enumeration may come from registry or fixed set; see [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175) for discovery). | Same. |
+| **modulation preset** | Today: **UART preset** (e.g. E220-style preset index). | Future: explicit SF/BW/CR when SPI or equivalent exposes them. |
+| **txPower** | Transmit power (step or dBm as defined by HW/registry). | Same. |
+
+The policy does not define the exact encoding of channel or preset; it requires that a profile identifies them and that a **default** profile exists with well-defined values.
+
+### 3.2 Profile kinds and pointers
+
+| Term | Meaning |
+|------|--------|
+| **Default profile** | Single, **immutable** profile that **MUST** always exist. Defined by product/firmware (or registry); not user-editable. Used when no user choice exists and after factory reset. |
+| **User profiles** | Zero or more profiles created or modified by the user (add/remove). Mutable. |
+| **CurrentProfileId** | Persisted **pointer** (id or handle) to the profile used for radio operation. **Used on boot** to restore last chosen profile. |
+| **PreviousProfileId** | Optional persisted pointer to the previously active profile; used for **rollback UX** (e.g. “revert to previous”). May be empty. |
+
+---
+
+## 4) Persistence semantics (pointers and expectations)
+
+- **Default profile** is always present; it is not stored as “user data” and is not removed by factory reset.
+- **User profiles** are stored in implementation-defined storage; policy only requires that they can be **added** and **removed** (or marked inactive).
+- **CurrentProfileId** MUST be persisted and MUST be used on boot to select the active profile. If it references a user profile that no longer exists (e.g. after partial reset), behavior is implementation-defined fallback (e.g. treat as “no current” and apply first-boot rule).
+- **PreviousProfileId** is optional; if present it MAY be used for rollback. No requirement to persist it across reboot; policy allows “clear previous” on factory reset.
+
+Storage format and location are out of scope; this section defines only **semantic** expectations.
+
+---
+
+## 5) First boot behavior
+
+**Rule:** If there is **no valid persisted CurrentProfileId** (first boot, or storage cleared), the device MUST:
+
+1. **Apply** the **default** profile (channel + modulation preset + txPower from the default profile).
+2. **Persist** CurrentProfileId so that it points to the default profile.
+3. Optionally clear or leave PreviousProfileId unspecified.
+
+After this, boot config is defined and OOTB behavior is deterministic for “default profile only” without user interaction.
+
+---
+
+## 6) Factory reset behavior
+
+**Rule:** Factory reset MUST:
+
+1. **Remove** all user profiles, or **mark** them inactive (implementation choice); the default profile MUST remain.
+2. Set **CurrentProfileId** to the default profile and persist it.
+3. **Clear** PreviousProfileId (or leave it empty).
+
+After factory reset, the device behaves as if “current = default” and no user profiles exist; first-boot rule is not re-triggered on next boot because CurrentProfileId is already set to default.
+
+---
+
+## 7) Minimal API surface (conceptual)
+
+The policy requires a minimal **conceptual** API; no UI or wire format is specified.
+
+| Operation | Meaning |
+|-----------|--------|
+| **list** | Return the set of available profiles (at least the default; plus any user profiles). |
+| **select** | Set CurrentProfileId to the given profile; optionally set PreviousProfileId to the previous current. Persist. |
+| **reset** | Perform factory reset as in §6 (remove or deactivate user profiles; current = default; clear previous). |
+
+Add/remove user profiles may be part of a larger “profile management” surface; for v0 the policy only requires that user profiles can be added and removed and that list/select/reset are defined as above.
+
+---
+
+## 8) Implementation notes (non-normative)
+
+- **E220 / UART:** Today modulation is typically expressed as a **UART preset** (e.g. index or name). The policy remains stable if future firmware exposes explicit SF/BW/CR (e.g. via SPI or another adapter); the profile model still holds channel + modulation preset (or explicit params) + txPower.
+- **Registry bundle ([#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184)):** Can deliver default profile definition or extended profile sets later. This policy does not depend on bundle delivery for OOTB defaults; the default profile may be firmware-built-in or loaded from a bundled registry. Layering: bundle format can deliver registries; OOTB defaults exist regardless.
+
+---
+
+**DoD (per [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211)):** Policy doc written; no contradictions with “OOTB defaults” principle (see [ai_model_policy](../../../../../dev/ai_model_policy.md)).

--- a/docs/product/wip/spec_map_v0.md
+++ b/docs/product/wip/spec_map_v0.md
@@ -39,7 +39,7 @@
 
 ### Open (what blocks progress)
 
-- Channel list source & local discovery flow → [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175).
+- Channel list source & local discovery flow → [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175). *Clarification: #175 is post V1-A; V0/V1-A uses deterministic OOTB default profile per [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211).*
 - Registry bundle format → [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184) doc added ([registry_bundle_format_v0](areas/registry/contract/registry_bundle_format_v0.md)); path/pipeline implementation when stable.
 - Secure claim protocol & threat model (if required for v1) → [#187](https://github.com/AlexanderTsarkov/naviga-app/issues/187); stub only today.
 - NodeTable implementation order / wiring for first slice → [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147).
@@ -69,6 +69,7 @@ Next 3–5 docs-only tasks are listed in **Next issues (proposed)** below; they 
 | Radio | [areas/radio/registry_radio_profiles_v0.md](areas/radio/registry_radio_profiles_v0.md) | Doc | v0 | RadioProfiles & ChannelPlan (Default/LongDist/Fast, profile–channel compatibility) | HW registry | [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175) (channel discovery) | — | **Y** — channel list/source and discovery flow not fully specified | — | MAYBE | Candidate |
 | Registry | [areas/registry/distribution_ownership_v0.md](areas/registry/distribution_ownership_v0.md) | Doc | v0 | Distribution & ownership (source of truth, bundling, schema rev, BT vs registry merge) | HW + Radio registries | — | — | N | — | IN | Ready |
 | Registry | [areas/registry/contract/registry_bundle_format_v0.md](areas/registry/contract/registry_bundle_format_v0.md) | Doc | v0 | Bundle format v0: schema (metadata, contents, registries), versioning, integrity, transport-independent, replace/merge semantics | distribution_ownership_v0, HW + Radio registries | [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184) | — | N | #184 bundle format contract | IN | Ready |
+| Radio policy | [areas/radio/policy/radio_profiles_policy_v0.md](areas/radio/policy/radio_profiles_policy_v0.md) | Doc | v0 | RadioProfile model; default (immutable) + user profiles; CurrentProfileId/PreviousProfileId; first boot; factory reset; minimal API (list/select/reset) | selection_policy, registry_radio_profiles | [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211) | — | N | OOTB defaults + persistence + factory reset | IN | Candidate |
 | Radio policy | [areas/radio/selection_policy_v0.md](areas/radio/selection_policy_v0.md) | Doc | v0 | SelectionPolicy (default profile/channel, throttling, user advice) | #159, #158 | [#180](https://github.com/AlexanderTsarkov/naviga-app/issues/180) (AutoPower) | — | N | — | IN | Ready |
 | Radio policy | [areas/radio/autopower_policy_v0.md](areas/radio/autopower_policy_v0.md) | Doc | v0 | AutoPower (node-side tx power, bounds, hysteresis, fallback) | #159, #158 | — | — | N | — | IN | Ready |
 | Radio policy | [areas/radio/policy/traffic_model_v0.md](areas/radio/policy/traffic_model_v0.md) | Doc | v0 | Traffic model: OOTB vs Session/Group; ProductMaxFrameBytes=96; no fragmentation; **mesh-lite beacon-only forwarding** (extras direct-link only) | Beacon encoding, NodeTable | — | — | N | Reference for cadence/mesh decisions | IN | Ready |
@@ -89,7 +90,7 @@ Next 3–5 docs-only tasks are listed in **Next issues (proposed)** below; they 
 |---------|-------|--------|--------|
 | Beacon payload & encoding (byte layout, airtime) | [#173](https://github.com/AlexanderTsarkov/naviga-app/issues/173) | Doc | Encoding contract done; implementation/validation in progress |
 | NodeTable as central consumer (implementation order, wiring) | [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147) | In progress | Single end-to-end slice until shape fixed |
-| Channel discovery & selection (channel list source, local discovery flow) | [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175) | Open | v1 slice if user-selectable channels required |
+| Channel discovery & selection (channel list source, local discovery flow) | [#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175) | Open | Post V1-A; V1-A uses deterministic OOTB default per [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211) |
 | Secure claim (stub; threat model / protocol TBD) | [#187](https://github.com/AlexanderTsarkov/naviga-app/issues/187) | Stub | Only if product requires ownership/anti-spoofing for first slice |
 | Registry bundle format (path, JSON vs per-registry; implementation when stable) | [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184) | Doc | Bundle format contract done ([registry_bundle_format_v0](areas/registry/contract/registry_bundle_format_v0.md)); app/firmware consumption can proceed |
 
@@ -116,9 +117,10 @@ List of next docs-only tasks that align with this map. Update when spec_map or p
 
 ---
 
-**Last updated:** 2026-02-16
+**Last updated:** 2026-02-19
 
 **Changelog:**
+- 2026-02-19: [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211) Radio profiles policy v0 — new [radio_profiles_policy_v0](areas/radio/policy/radio_profiles_policy_v0.md) (defaults, persistence, factory reset, first boot, minimal API). Spec_map: Inventory row added (IN, Candidate); #175 clarified as post V1-A, V1-A uses OOTB default per #211 (Open + Blockers).
 - 2026-02-16: [#184](https://github.com/AlexanderTsarkov/naviga-app/issues/184) Registry bundle format v0: new contract [registry_bundle_format_v0](areas/registry/contract/registry_bundle_format_v0.md) (schema, versioning, integrity, transport-independent, replace/merge). Spec_map: Inventory + Blocker + Open + Next updated; NodeTable Next 6–7 removed (done); field_cadence note → seq16 canonical (PR #205).
 - 2026-02-16: PR #205 merged — Alive packet + RX semantics; Core only with fix; seq16 scope unified. Inventory: [alive_packet_encoding_v0](areas/nodetable/contract/alive_packet_encoding_v0.md), [rx_semantics_v0](areas/nodetable/policy/rx_semantics_v0.md) added as IN/Ready; beacon_payload_encoding note updated. [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147)
 - 2026-02-16: Spec snapshot & V1-A lens: Inventory table +2 columns (V1-A? IN/OUT/MAYBE, Promote Idea/Candidate/Ready); NodeTable index Links updated (no orphans: beacon_payload_encoding, field_cadence, nodetable_fields_inventory, position_quality, activity_state, link_metrics). Status snapshot for [#147](https://github.com/AlexanderTsarkov/naviga-app/issues/147) in PR. Docs-only.


### PR DESCRIPTION
**Issue:** [#211](https://github.com/AlexanderTsarkov/naviga-app/issues/211) — Radio Profiles v0: defaults + persistence + factory reset

**Scope (docs-only):**
- New policy doc: `docs/product/wip/areas/radio/policy/radio_profiles_policy_v0.md`
  - RadioProfile model (channel + modulation preset UART / future SF/BW/CR + txPower)
  - Default (immutable) + user profiles; CurrentProfileId / PreviousProfileId
  - First boot rule; factory reset semantics; minimal API (list/select/reset)
  - Explicit V0/V1-A baseline for deterministic OOTB
- spec_map update: Inventory row for new doc (IN, Candidate, #211); #175 clarified as post V1-A (Open + Blockers)

**Non-goals:** No change to #175 issue body; no discovery algorithm; no OOTB/UI as source of truth; no code.

Made with [Cursor](https://cursor.com)