### PR TITLE
FW: E220 verify-and-repair on boot (F2)

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -151,6 +151,22 @@ void AppServices::init() {
   static E220Radio radio_instance(profile.pins);
   radio = &radio_instance;
   const bool radio_ready = radio->begin();
+  {
+    char buf[80] = {0};
+    switch (radio->last_boot_config_result()) {
+      case E220BootConfigResult::Ok:
+        log_line("E220 boot: config ok");
+        break;
+      case E220BootConfigResult::Repaired:
+        std::snprintf(buf, sizeof(buf), "E220 boot: repaired (%s)", radio->last_boot_config_message());
+        log_line(buf);
+        break;
+      case E220BootConfigResult::RepairFailed:
+        std::snprintf(buf, sizeof(buf), "E220 boot: repair failed (%s)", radio->last_boot_config_message());
+        log_line(buf);
+        break;
+    }
+  }
   format_short_id_hex(short_id_, short_id_hex_, sizeof(short_id_hex_));
   format_mac_colon_hex(mac_bytes, mac_hex_, sizeof(mac_hex_));
   extract_bt_short(mac_hex_, bt_short_, sizeof(bt_short_));

--- a/firmware/src/platform/e220_radio.cpp
+++ b/firmware/src/platform/e220_radio.cpp
@@ -9,6 +9,58 @@ namespace {
 
 constexpr UART_BPS_RATE kE220BaudRate = UART_BPS_RATE_9600;
 
+// Expected critical params per module_boot_config_v0 (verify-and-repair every boot).
+constexpr byte kExpectedUartBaudRate = UART_BPS_9600;
+constexpr byte kExpectedUartParity = MODE_00_8N1;
+constexpr byte kExpectedRssiEnable = RSSI_ENABLED;
+constexpr byte kExpectedLbtEnable = 0;  // OFF — policy: sense unsupported, jitter-only.
+constexpr byte kExpectedSubPacketSetting = SPS_200_00;
+constexpr byte kExpectedRssiAmbientNoise = RSSI_AMBIENT_NOISE_ENABLED;  // Align with RSSI byte ON.
+
+// Returns true if critical fields of cfg match expected values.
+bool critical_params_match(const Configuration& cfg) {
+  return cfg.SPED.uartBaudRate == kExpectedUartBaudRate &&
+         cfg.SPED.uartParity == kExpectedUartParity &&
+         cfg.TRANSMISSION_MODE.enableRSSI == kExpectedRssiEnable &&
+         cfg.TRANSMISSION_MODE.enableLBT == kExpectedLbtEnable &&
+         cfg.OPTION.subPacketSetting == kExpectedSubPacketSetting &&
+         cfg.OPTION.RSSIAmbientNoise == kExpectedRssiAmbientNoise;
+}
+
+// Overwrites only critical fields in cfg with expected values (rest unchanged).
+void apply_expected_critical(Configuration* cfg) {
+  cfg->SPED.uartBaudRate = kExpectedUartBaudRate;
+  cfg->SPED.uartParity = kExpectedUartParity;
+  cfg->TRANSMISSION_MODE.enableRSSI = kExpectedRssiEnable;
+  cfg->TRANSMISSION_MODE.enableLBT = kExpectedLbtEnable;
+  cfg->OPTION.subPacketSetting = kExpectedSubPacketSetting;
+  cfg->OPTION.RSSIAmbientNoise = kExpectedRssiAmbientNoise;
+}
+
+// Builds a short comma-separated list of what differed (for log).
+void describe_mismatch(const Configuration& current, char* out, size_t out_len) {
+  if (out_len == 0) return;
+  char* p = out;
+  size_t remain = out_len;
+  auto append = [&](const char* tag) {
+    const size_t tag_len = std::strlen(tag);
+    if (p > out) {
+      if (remain >= 3) { *p++ = ','; *p++ = ' '; remain -= 2; }
+    }
+    if (remain > tag_len) {
+      std::memcpy(p, tag, tag_len + 1);
+      p += tag_len;
+      remain -= tag_len;
+    }
+  };
+  if (current.SPED.uartBaudRate != kExpectedUartBaudRate) append("baud");
+  if (current.SPED.uartParity != kExpectedUartParity) append("parity");
+  if (current.TRANSMISSION_MODE.enableRSSI != kExpectedRssiEnable) append("rssi");
+  if (current.TRANSMISSION_MODE.enableLBT != kExpectedLbtEnable) append("lbt");
+  if (current.OPTION.subPacketSetting != kExpectedSubPacketSetting) append("subpkt");
+  if (current.OPTION.RSSIAmbientNoise != kExpectedRssiAmbientNoise) append("rssi_amb");
+}
+
 } // namespace
 
 E220Radio::E220Radio(const Pins& pins)
@@ -18,23 +70,67 @@ E220Radio::E220Radio(const Pins& pins)
              static_cast<byte>(pins.lora_m1), kE220BaudRate, SERIAL_8N1) {}
 
 bool E220Radio::begin() {
+  last_boot_result_ = E220BootConfigResult::Ok;
+  last_boot_message_[0] = '\0';
+
   ready_ = radio_.begin();
   if (!ready_) {
     return false;
   }
 
+  // Verify-and-repair critical params every boot (module_boot_config_v0).
   ResponseStructContainer config = radio_.getConfiguration();
-  if (config.status.code == E220_SUCCESS && config.data) {
-    Configuration* cfg = reinterpret_cast<Configuration*>(config.data);
-    cfg->TRANSMISSION_MODE.enableRSSI = RSSI_ENABLED;
-    ResponseStatus status = radio_.setConfiguration(*cfg, WRITE_CFG_PWR_DWN_LOSE);
-    if (status.code == E220_SUCCESS) {
-      rssi_enabled_ = true;
-    }
+  if (config.status.code != E220_SUCCESS || !config.data) {
     config.close();
+    last_boot_result_ = E220BootConfigResult::RepairFailed;
+    std::snprintf(last_boot_message_, kBootMessageLen, "read failed");
+    rssi_enabled_ = (kExpectedRssiEnable == RSSI_ENABLED);
+    return true;  // Proceed; caller can log warning.
   }
 
-  return ready_;
+  Configuration* cfg = reinterpret_cast<Configuration*>(config.data);
+  if (critical_params_match(*cfg)) {
+    rssi_enabled_ = (cfg->TRANSMISSION_MODE.enableRSSI == RSSI_ENABLED);
+    config.close();
+    return true;
+  }
+
+  // Mismatch: repair once (apply expected critical, write, re-read, verify).
+  describe_mismatch(*cfg, last_boot_message_, kBootMessageLen);
+  apply_expected_critical(cfg);
+  ResponseStatus write_status = radio_.setConfiguration(*cfg, WRITE_CFG_PWR_DWN_LOSE);
+  config.close();
+
+  if (write_status.code != E220_SUCCESS) {
+    last_boot_result_ = E220BootConfigResult::RepairFailed;
+    std::snprintf(last_boot_message_, kBootMessageLen, "write failed");
+    rssi_enabled_ = (kExpectedRssiEnable == RSSI_ENABLED);
+    return true;  // Module is up; use expected params for our state.
+  }
+
+  ResponseStructContainer config2 = radio_.getConfiguration();
+  if (config2.status.code != E220_SUCCESS || !config2.data) {
+    last_boot_result_ = E220BootConfigResult::RepairFailed;
+    std::snprintf(last_boot_message_, kBootMessageLen, "re-read failed");
+    config2.close();
+    rssi_enabled_ = (kExpectedRssiEnable == RSSI_ENABLED);
+    return true;
+  }
+
+  Configuration* cfg2 = reinterpret_cast<Configuration*>(config2.data);
+  bool verified = critical_params_match(*cfg2);
+  rssi_enabled_ = (cfg2->TRANSMISSION_MODE.enableRSSI == RSSI_ENABLED);
+  config2.close();
+
+  if (verified) {
+    last_boot_result_ = E220BootConfigResult::Repaired;
+    // last_boot_message_ already set to mismatch list (what we repaired).
+  } else {
+    last_boot_result_ = E220BootConfigResult::RepairFailed;
+    std::snprintf(last_boot_message_, kBootMessageLen, "verify failed");
+  }
+
+  return true;
 }
 
 bool E220Radio::is_ready() const {

--- a/firmware/src/platform/e220_radio.h
+++ b/firmware/src/platform/e220_radio.h
@@ -11,6 +11,12 @@
 
 namespace naviga {
 
+enum class E220BootConfigResult {
+  Ok,          // Critical params already match; no repair.
+  Repaired,    // Mismatch was repaired and re-verified.
+  RepairFailed // Repair attempted but re-read did not match (or write failed).
+};
+
 class E220Radio : public IRadio {
  public:
   explicit E220Radio(const Pins& pins);
@@ -18,6 +24,11 @@ class E220Radio : public IRadio {
   bool begin();
   bool is_ready() const;
   bool rssi_available() const;
+
+  /** Result of last begin() verify-and-repair (per module_boot_config_v0). */
+  E220BootConfigResult last_boot_config_result() const { return last_boot_result_; }
+  /** Short message for log: what was repaired or failure reason; empty if Ok. */
+  const char* last_boot_config_message() const { return last_boot_message_; }
 
   bool send(const uint8_t* data, size_t len) override;
   bool recv(uint8_t* out, size_t max_len, size_t* out_len) override;
@@ -30,6 +41,10 @@ class E220Radio : public IRadio {
   bool ready_ = false;
   bool rssi_enabled_ = false;
   int8_t last_rssi_dbm_ = 0;
+
+  E220BootConfigResult last_boot_result_ = E220BootConfigResult::Ok;
+  static constexpr size_t kBootMessageLen = 48;
+  char last_boot_message_[kBootMessageLen] = {};
 };
 
 } // namespace naviga


### PR DESCRIPTION
## Summary

Implements **verify-and-repair on every boot** for the E220 module per `module_boot_config_v0` (F2, #245). No change to public IRadio API or to mesh/JOIN/CAD/LBT.

- **E220Radio::begin():** Reads current module config, compares critical parameters to expected values; on mismatch applies repair (setConfiguration), then re-reads and verifies. At most one repair attempt.
- **Critical params (policy):** RSSI byte ON, LBT OFF, UART baud/parity (9600 8N1), sub-packet (200), RSSI ambient/enable aligned with RSSI byte.
- **Logging:** One compact line from `AppServices::init()`: `E220 boot: config ok` | `E220 boot: repaired (rssi,lbt,...)` | `E220 boot: repair failed (reason)`.

## Critical params covered

| Param | Expected | Source |
|-------|----------|--------|
| Enable RSSI Byte | ON | module_boot_config_v0 |
| LBT Enable | OFF | module_boot_config_v0 (sense unsupported; jitter-only) |
| UART baud | 9600 | Product (kE220BaudRate) |
| UART parity | 8N1 | Product |
| Sub-packet | 200 bytes | module_boot_config_v0 / beacon encoding |
| RSSI ambient/enable | Enabled | Align with RSSI byte ON |

## Non-goals (unchanged)

- No SPI driver; no real CAD/LBT; no NVS/provisioning/role/profile (F4–F6); no mesh/JOIN/packet format changes.
- Channel sense remains OFF/UNSUPPORTED; no change to public contracts.

## Refs

- Issue: #245
- Audit: #228 (F2 follow-up)
- Canon: `docs/product/areas/firmware/policy/module_boot_config_v0.md`, `boot_pipeline_v0.md`
