### PR TITLE
FW: add NVS persistence stub for role/profile pointers (F4)

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -169,8 +169,8 @@ void AppServices::init() {
     }
   }
 
-  // --- Phase B: Provision role + radio profile (boot_pipeline_v0). Stub until F4/F5. ---
-  // (No persisted load/apply here yet.)
+  // --- Phase B: Provision role + radio profile (boot_pipeline_v0). Stub until F5. ---
+  // F4: naviga_storage provides load_pointers/save_pointers; F5 will load and apply here.
 
   // --- Phase C: Start comms — wire runtime; tick() runs Alive/Beacon cadence ---
   format_short_id_hex(short_id_, short_id_hex_, sizeof(short_id_hex_));

--- a/firmware/src/platform/naviga_storage.cpp
+++ b/firmware/src/platform/naviga_storage.cpp
@@ -1,0 +1,77 @@
+#include "platform/naviga_storage.h"
+
+#include <Preferences.h>
+
+namespace naviga {
+
+namespace {
+
+constexpr char kNamespace[] = "naviga";
+constexpr char kKeyCurrentRole[] = "role_cur";
+constexpr char kKeyCurrentRadio[] = "prof_cur";
+constexpr char kKeyPreviousRole[] = "role_prev";
+constexpr char kKeyPreviousRadio[] = "prof_prev";
+
+}  // namespace
+
+bool load_pointers(PersistedPointers* out) {
+  if (!out) {
+    return false;
+  }
+  *out = PersistedPointers{};
+
+  Preferences prefs;
+  if (!prefs.begin(kNamespace, true)) {  // read-only
+    return false;
+  }
+
+  out->current_role_id = prefs.getUInt(kKeyCurrentRole, 0);
+  out->has_current_role = prefs.isKey(kKeyCurrentRole);
+
+  out->current_radio_profile_id = prefs.getUInt(kKeyCurrentRadio, 0);
+  out->has_current_radio = prefs.isKey(kKeyCurrentRadio);
+
+  out->previous_role_id = prefs.getUInt(kKeyPreviousRole, 0);
+  out->has_previous_role = prefs.isKey(kKeyPreviousRole);
+
+  out->previous_radio_profile_id = prefs.getUInt(kKeyPreviousRadio, 0);
+  out->has_previous_radio = prefs.isKey(kKeyPreviousRadio);
+
+  prefs.end();
+  return true;
+}
+
+bool save_pointers(uint32_t current_role_id,
+                   uint32_t current_radio_profile_id,
+                   uint32_t previous_role_id,
+                   uint32_t previous_radio_profile_id) {
+  Preferences prefs;
+  if (!prefs.begin(kNamespace, false)) {  // read-write
+    return false;
+  }
+
+  prefs.putUInt(kKeyCurrentRole, current_role_id);
+  prefs.putUInt(kKeyCurrentRadio, current_radio_profile_id);
+  prefs.putUInt(kKeyPreviousRole, previous_role_id);
+  prefs.putUInt(kKeyPreviousRadio, previous_radio_profile_id);
+
+  prefs.end();
+  return true;
+}
+
+bool factory_reset_pointers() {
+  Preferences prefs;
+  if (!prefs.begin(kNamespace, false)) {
+    return false;
+  }
+
+  prefs.remove(kKeyCurrentRole);
+  prefs.remove(kKeyCurrentRadio);
+  prefs.remove(kKeyPreviousRole);
+  prefs.remove(kKeyPreviousRadio);
+
+  prefs.end();
+  return true;
+}
+
+}  // namespace naviga

--- a/firmware/src/platform/naviga_storage.h
+++ b/firmware/src/platform/naviga_storage.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+
+namespace naviga {
+
+/**
+ * Persisted pointers for Phase B (boot_pipeline_v0) and provisioning (provisioning_interface_v0).
+ * CurrentRoleId / CurrentRadioProfileId / PreviousRoleId / PreviousRadioProfileId.
+ * Opaque uint32 ids; F5/F6 resolve to role/profile content.
+ */
+struct PersistedPointers {
+  uint32_t current_role_id = 0;
+  uint32_t current_radio_profile_id = 0;
+  uint32_t previous_role_id = 0;
+  uint32_t previous_radio_profile_id = 0;
+  bool has_current_role = false;
+  bool has_current_radio = false;
+  bool has_previous_role = false;
+  bool has_previous_radio = false;
+};
+
+/**
+ * Load persisted pointers from NVS (namespace "naviga").
+ * Returns true if NVS was opened and read; out is filled (missing keys leave has_* false).
+ */
+bool load_pointers(PersistedPointers* out);
+
+/**
+ * Save pointers to NVS. Immediate persistence per provisioning_interface_v0.
+ * Returns true on success.
+ */
+bool save_pointers(uint32_t current_role_id,
+                   uint32_t current_radio_profile_id,
+                   uint32_t previous_role_id,
+                   uint32_t previous_radio_profile_id);
+
+/**
+ * Clear all role/radio pointer keys (factory reset of pointers only).
+ * Returns true on success.
+ */
+bool factory_reset_pointers();
+
+}  // namespace naviga


### PR DESCRIPTION
## Scope

Minimal NVS persistence for Phase B (boot_pipeline_v0) and provisioning (provisioning_interface_v0) pointers. No Phase B wiring yet (F5); no provisioning commands (F6).

## What’s added

- **Module:** `platform/naviga_storage.h` + `naviga_storage.cpp`
- **NVS namespace:** `naviga`
- **Keys:** `role_cur`, `prof_cur`, `role_prev`, `prof_prev` (CurrentRoleId, CurrentRadioProfileId, PreviousRoleId, PreviousRadioProfileId)
- **API:** `load_pointers(PersistedPointers*)`, `save_pointers(...)`, `factory_reset_pointers()`
- **Types:** Opaque `uint32_t` ids; F5/F6 resolve to role/profile content.

## Non-goals (unchanged)

- No default application or runtime wiring (F5).
- No serial provisioning commands (F6).
- No protocol/NodeTable/mesh/JOIN/CAD/LBT changes.

## Refs

- **#247** (F4)
- Epic **#224**

Made with [Cursor](https://cursor.com)