### PR TITLE
FW: GNSS verify-on-boot (lightweight) (F3)

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -146,6 +146,15 @@ void AppServices::init() {
   gnss_provider_.set_io(&gnss_ubx_io_);
 #endif
   gnss_provider_.init(full_id);
+  constexpr uint32_t kGnssVerifyTimeoutMs = 500U;
+  const bool first_verify = gnss_provider_.verify_on_boot(kGnssVerifyTimeoutMs);
+  if (first_verify) {
+    log_line("GNSS boot: ok");
+  } else {
+    gnss_provider_.init(full_id);
+    const bool second_verify = gnss_provider_.verify_on_boot(kGnssVerifyTimeoutMs);
+    log_line(second_verify ? "GNSS boot: repaired" : "GNSS boot: failed");
+  }
   self_policy.init();
 #if defined(GNSS_PROVIDER_UBLOX) && GNSS_UBLOX_DIAG
   gnss_diag_next_ms = 0;

--- a/firmware/src/services/gnss_stub_service.cpp
+++ b/firmware/src/services/gnss_stub_service.cpp
@@ -95,6 +95,10 @@ bool GnssStubService::tick(uint32_t now_ms) {
   return true;
 }
 
+bool GnssStubService::verify_on_boot(uint32_t /*timeout_ms*/) {
+  return true;  // No hardware; nothing to verify.
+}
+
 bool GnssStubService::get_snapshot(GnssSnapshot* out) {
   if (!out) {
     return false;

--- a/firmware/src/services/gnss_stub_service.h
+++ b/firmware/src/services/gnss_stub_service.h
@@ -12,6 +12,8 @@ class GnssStubService : public IGnss {
  public:
   void init(uint64_t seed);
   bool tick(uint32_t now_ms);
+  /** Lightweight verify: stub has no hardware; always reports ok. */
+  bool verify_on_boot(uint32_t timeout_ms);
   bool get_snapshot(GnssSnapshot* out) override;
 
  private:

--- a/firmware/src/services/gnss_ublox_service.h
+++ b/firmware/src/services/gnss_ublox_service.h
@@ -42,6 +42,8 @@ class GnssUbloxService : public IGnss {
   void set_io(IGnssUbxIo* io);
   void init(uint64_t seed);
   bool tick(uint32_t now_ms);
+  /** Lightweight verify: within timeout_ms, run tick until at least one byte received from GNSS UART. */
+  bool verify_on_boot(uint32_t timeout_ms);
   bool get_snapshot(GnssSnapshot* out) override;
   bool get_diag(GnssUbloxDiag* out) const;
   bool take_diag_events(GnssUbloxDiagEvents* out);


### PR DESCRIPTION
## Summary

Adds **lightweight GNSS verify-on-boot** (F3, #246): one quick check after GNSS init, one soft re-init on failure, then one line of boot log.

### Behavior

- **Phase A (after GNSS init):** Run `verify_on_boot(timeout_ms)` (500 ms).
  - **Stub:** Always returns true (no hardware).
  - **Ublox:** Loops calling `tick()` until at least one byte is received from the GNSS UART, or timeout.
- **On first verify failure:** One soft re-init (`init()` again), then `verify_on_boot(500)` again.
- **Boot log (exactly one line):** `GNSS boot: ok` | `GNSS boot: repaired` | `GNSS boot: failed`.

### Verify implementation

- **Bounded wait:** Loop `while (uptime_ms() - start < timeout_ms)`; no unbounded blocking.
- **Success condition (Ublox):** `get_diag()->bytes_rx > 0` (GNSS is outputting data).
- **One retry only:** Single re-init and second verify.

### Non-goals (unchanged)

- No BLE/BT/pairing; no protocol/NodeTable changes; no complex UBX config; no long blocking in main loop.

### Refs

- Issue: #246
- Epic: #224
