### PR TITLE
#258 Rename provisioning boot-info API to radio-generic

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -186,8 +186,8 @@ void AppServices::init() {
         break;
     }
   }
-  provisioning_->set_e220_boot_info(static_cast<int>(radio->last_boot_config_result()),
-                                           radio->last_boot_config_message());
+  provisioning_->set_radio_boot_info(static_cast<int>(radio->last_boot_config_result()),
+                                    radio->last_boot_config_message());
 
   // --- Phase B: Provision role + radio profile (boot_pipeline_v0) ---
   // Defaults per role_profiles_policy_v0 / radio_profiles_policy_v0. Id 0 = Person (18s), Dog (9), Infra (360). Radio 0 = channel 1.

--- a/firmware/src/platform/provisioning_adapter.cpp
+++ b/firmware/src/platform/provisioning_adapter.cpp
@@ -9,8 +9,8 @@
 
 namespace naviga {
 
-void ProvisioningAdapter::set_e220_boot_info(int result_enum, const char* message) {
-  shell_.set_e220_boot_info(result_enum, message);
+void ProvisioningAdapter::set_radio_boot_info(int result_enum, const char* message) {
+  shell_.set_radio_boot_info(result_enum, message);
 }
 
 void ProvisioningAdapter::tick(uint32_t /*now_ms*/) {

--- a/firmware/src/platform/provisioning_adapter.h
+++ b/firmware/src/platform/provisioning_adapter.h
@@ -13,8 +13,8 @@ namespace naviga {
  */
 class ProvisioningAdapter {
  public:
-  /** Call once after E220 begin(); result_enum = E220BootConfigResult (0=Ok, 1=Repaired, 2=RepairFailed). */
-  void set_e220_boot_info(int result_enum, const char* message);
+  /** Call once after radio modem begin(); result_enum = 0=Ok, 1=Repaired, 2=RepairFailed. */
+  void set_radio_boot_info(int result_enum, const char* message);
 
   /** Read one line (non-blocking), handle via shell, print response; at most one line per call. */
   void tick(uint32_t now_ms);

--- a/firmware/src/services/provisioning_shell.cpp
+++ b/firmware/src/services/provisioning_shell.cpp
@@ -42,16 +42,16 @@ void split_tokens(const char* line, char* t0, size_t len0, char* t1, size_t len1
 
 }  // namespace
 
-void ProvisioningShell::set_e220_boot_info(int result_enum, const char* message) {
-  e220_result_ = result_enum;
+void ProvisioningShell::set_radio_boot_info(int result_enum, const char* message) {
+  radio_boot_result_ = result_enum;
   if (message) {
-    std::snprintf(e220_message_, sizeof(e220_message_), "%s", message);
+    std::snprintf(radio_boot_message_, sizeof(radio_boot_message_), "%s", message);
   } else {
-    e220_message_[0] = '\0';
+    radio_boot_message_[0] = '\0';
   }
 }
 
-const char* ProvisioningShell::e220_result_str(int result_enum) {
+const char* ProvisioningShell::radio_boot_result_str(int result_enum) {
   switch (result_enum) {
     case 0: return "OK";
     case 1: return "REPAIRED";
@@ -83,14 +83,14 @@ bool ProvisioningShell::handle_line(const char* line,
     const bool loaded = load_pointers(&ptrs);
     const char* source = (loaded && ptrs.has_current_role && ptrs.has_current_radio) ? "persisted" : "default";
     std::snprintf(out_response, out_response_size,
-                 "role_cur=%lu role_prev=%lu radio_cur=%lu radio_prev=%lu source=%s e220_boot=%s e220_msg=\"%s\"",
+                 "role_cur=%lu role_prev=%lu radio_cur=%lu radio_prev=%lu source=%s radio_boot=%s radio_boot_msg=\"%s\"",
                  static_cast<unsigned long>(ptrs.current_role_id),
                  static_cast<unsigned long>(ptrs.previous_role_id),
                  static_cast<unsigned long>(ptrs.current_radio_profile_id),
                  static_cast<unsigned long>(ptrs.previous_radio_profile_id),
                  source,
-                 e220_result_str(e220_result_),
-                 e220_message_);
+                 radio_boot_result_str(radio_boot_result_),
+                 radio_boot_message_);
     return true;
   }
   if (std::strcmp(t0, "get") == 0) {

--- a/firmware/src/services/provisioning_shell.h
+++ b/firmware/src/services/provisioning_shell.h
@@ -15,8 +15,8 @@ class ProvisioningShell {
   static constexpr size_t kResponseMax = 256;
   static constexpr size_t kLineMax = 128;
 
-  /** Call once after E220 begin(); result_enum = E220BootConfigResult (0=Ok, 1=Repaired, 2=RepairFailed). */
-  void set_e220_boot_info(int result_enum, const char* message);
+  /** Call once after radio modem begin(); result_enum = 0=Ok, 1=Repaired, 2=RepairFailed. */
+  void set_radio_boot_info(int result_enum, const char* message);
 
   /**
    * Parse and execute one command line. Fills out_response with reply text (null-terminated).
@@ -29,10 +29,10 @@ class ProvisioningShell {
                    bool* reboot_requested = nullptr);
 
  private:
-  static const char* e220_result_str(int result_enum);
+  static const char* radio_boot_result_str(int result_enum);
 
-  int e220_result_ = 0;
-  char e220_message_[48] = {};
+  int radio_boot_result_ = 0;
+  char radio_boot_message_[48] = {};
 };
 
 }  // namespace naviga


### PR DESCRIPTION
Closes #258

**Summary:** Rename provisioning boot-info API from E220-specific to radio-generic. No behavior or protocol changes; platform-agnostic provisioning layer no longer exposes "E220" in method/field names or status output labels. Addresses audit gap G1 from #229.

**Files touched:**
- `firmware/src/services/provisioning_shell.h` — `set_radio_boot_info`, `radio_boot_result_`, `radio_boot_message_`, `radio_boot_result_str`
- `firmware/src/services/provisioning_shell.cpp` — same renames; status line `radio_boot=` / `radio_boot_msg=`
- `firmware/src/platform/provisioning_adapter.h` — `set_radio_boot_info`
- `firmware/src/platform/provisioning_adapter.cpp` — delegate to shell
- `firmware/src/app/app_services.cpp` — call site `set_radio_boot_info(...)`

**Epic:** #224 · **Audit:** #229
