### PR TITLE
FW: Add HW acceptance instrumentation (packet kind + peer dump)

### DIFF
--- a/firmware/src/app/app_services.h
+++ b/firmware/src/app/app_services.h
@@ -18,10 +18,15 @@ class AppServices {
   void init();
   void tick(uint32_t now_ms);
 
+  /** Called by instrumentation logger callback when instrumentation is enabled. */
+  void log_instrumentation_line(const char* line);
+
  private:
   uint32_t last_heartbeat_ms_ = 0;
   uint32_t last_summary_ms_ = 0;
+  uint32_t last_peer_dump_ms_ = 0;
   bool fix_logged_ = false;
+  bool instrumentation_enabled_ = false;
   RadioRole role_ = RadioRole::RESP;
   uint16_t short_id_ = 0;
   char short_id_hex_[5] = {0};

--- a/firmware/src/app/m1_runtime.h
+++ b/firmware/src/app/m1_runtime.h
@@ -43,6 +43,10 @@ class M1Runtime {
   uint16_t geo_seq() const;
   bool ble_connected() const;
 
+  /** Optional instrumentation: when set, TX/RX and peer dump are logged. */
+  void set_instrumentation_logger(void (*log_line_fn)(const char* line, void* ctx), void* ctx);
+  void log_peer_dump(uint32_t now_ms);
+
  private:
   void handle_tx(uint32_t now_ms);
   void handle_rx(uint32_t now_ms);
@@ -74,6 +78,9 @@ class M1Runtime {
   RadioSmokeStats stats_{};
   uint8_t pending_payload_[protocol::kGeoBeaconSize] = {};
   size_t pending_len_ = 0;
+
+  void (*instrumentation_log_fn_)(const char* line, void* ctx) = nullptr;
+  void* instrumentation_ctx_ = nullptr;
 };
 
 } // namespace naviga

--- a/firmware/src/domain/beacon_logic.cpp
+++ b/firmware/src/domain/beacon_logic.cpp
@@ -48,14 +48,21 @@ bool BeaconLogic::on_rx(uint32_t now_ms,
                         const uint8_t* payload,
                         size_t len,
                         int8_t rssi_dbm,
-                        NodeTable& table) {
+                        NodeTable& table,
+                        uint64_t* out_node_id,
+                        uint16_t* out_seq) {
   protocol::GeoBeaconFields fields{};
   const protocol::DecodeError err =
       protocol::decode_geo_beacon(protocol::ConstByteSpan{payload, len}, &fields);
   if (err != protocol::DecodeError::Ok) {
     return false;
   }
-
+  if (out_node_id) {
+    *out_node_id = fields.node_id;
+  }
+  if (out_seq) {
+    *out_seq = fields.seq;
+  }
   return table.upsert_remote(fields.node_id,
                              fields.pos_valid != 0,
                              fields.lat_e7,

--- a/firmware/src/domain/beacon_logic.h
+++ b/firmware/src/domain/beacon_logic.h
@@ -26,7 +26,9 @@ class BeaconLogic {
              const uint8_t* payload,
              size_t len,
              int8_t rssi_dbm,
-             NodeTable& table);
+             NodeTable& table,
+             uint64_t* out_node_id = nullptr,
+             uint16_t* out_seq = nullptr);
 
   uint16_t seq() const {
     return seq_;

--- a/firmware/src/domain/node_table.h
+++ b/firmware/src/domain/node_table.h
@@ -53,6 +53,9 @@ class NodeTable {
                   uint8_t* out_buffer,
                   size_t out_capacity) const;
 
+  /** Format one peer for instrumentation dump; peer_index 0-based (0 = first non-self). Returns length or 0. */
+  size_t get_peer_dump_line(uint32_t now_ms, size_t peer_index, char* buf, size_t cap) const;
+
   uint16_t create_snapshot(uint32_t now_ms);
   size_t get_snapshot_page(uint16_t snapshot_id,
                            size_t page_index,

--- a/firmware/src/platform/provisioning_adapter.cpp
+++ b/firmware/src/platform/provisioning_adapter.cpp
@@ -13,6 +13,10 @@ void ProvisioningAdapter::set_radio_boot_info(int result_enum, const char* messa
   shell_.set_radio_boot_info(result_enum, message);
 }
 
+void ProvisioningAdapter::set_instrumentation_flag(bool* flag) {
+  shell_.set_instrumentation_flag(flag);
+}
+
 void ProvisioningAdapter::tick(uint32_t /*now_ms*/) {
   if (!Serial || Serial.available() <= 0) return;
   while (Serial.available() > 0 && line_len_ < ProvisioningShell::kLineMax - 1) {

--- a/firmware/src/platform/provisioning_adapter.h
+++ b/firmware/src/platform/provisioning_adapter.h
@@ -16,6 +16,9 @@ class ProvisioningAdapter {
   /** Call once after radio modem begin(); result_enum = 0=Ok, 1=Repaired, 2=RepairFailed. */
   void set_radio_boot_info(int result_enum, const char* message);
 
+  /** Optional: enable "debug on/off" in shell to toggle instrumentation (e.g. packet/peer logs). */
+  void set_instrumentation_flag(bool* flag);
+
   /** Read one line (non-blocking), handle via shell, print response; at most one line per call. */
   void tick(uint32_t now_ms);
 

--- a/firmware/src/services/provisioning_shell.cpp
+++ b/firmware/src/services/provisioning_shell.cpp
@@ -75,7 +75,25 @@ bool ProvisioningShell::handle_line(const char* line,
 
   if (std::strcmp(t0, "help") == 0) {
     std::snprintf(out_response, out_response_size,
-                  "help|status|get role|get radio|set role <0-2>|set radio <0>|reset|reboot");
+                  "help|status|get role|get radio|set role <0-2>|set radio <0>|reset|reboot|debug on|off");
+    return true;
+  }
+  if (std::strcmp(t0, "debug") == 0) {
+    if (!instrumentation_flag_) {
+      std::snprintf(out_response, out_response_size, "ERR: instrumentation not available");
+      return true;
+    }
+    if (std::strcmp(t1, "on") == 0) {
+      *instrumentation_flag_ = true;
+      std::snprintf(out_response, out_response_size, "OK; instrumentation on");
+      return true;
+    }
+    if (std::strcmp(t1, "off") == 0) {
+      *instrumentation_flag_ = false;
+      std::snprintf(out_response, out_response_size, "OK; instrumentation off");
+      return true;
+    }
+    std::snprintf(out_response, out_response_size, "ERR: debug on|off");
     return true;
   }
   if (std::strcmp(t0, "status") == 0) {

--- a/firmware/src/services/provisioning_shell.h
+++ b/firmware/src/services/provisioning_shell.h
@@ -18,6 +18,9 @@ class ProvisioningShell {
   /** Call once after radio modem begin(); result_enum = 0=Ok, 1=Repaired, 2=RepairFailed. */
   void set_radio_boot_info(int result_enum, const char* message);
 
+  /** Optional: when set, "debug on" / "debug off" toggle *flag (e.g. instrumentation logging). */
+  void set_instrumentation_flag(bool* flag) { instrumentation_flag_ = flag; }
+
   /**
    * Parse and execute one command line. Fills out_response with reply text (null-terminated).
    * If the command is "reboot", sets *reboot_requested = true (caller must perform restart).
@@ -33,6 +36,7 @@ class ProvisioningShell {
 
   int radio_boot_result_ = 0;
   char radio_boot_message_[48] = {};
+  bool* instrumentation_flag_ = nullptr;
 };
 
 }  // namespace naviga


### PR DESCRIPTION
Closes #272.

Adds minimal FW instrumentation for HW acceptance #269 / #270 (observability for #268 re-run):
- **Packet kind logs:** TX/RX lines with `kind=BEACON`, `seq`, `t_ms`; RX adds `from=` (shortId) and `rssi`.
- **Periodic peer dump:** Every 3 s when instrumentation is on, up to 3 peers per line: `shortId`, `ageS`, `grey`, `seq`, `rssi`, `posAgeS`.
- **Runtime toggle:** Provisioning shell `debug on` / `debug off`; no protocol/cadence/NodeTable changes; output bounded.

Refs: #224, #269, #270.

**Sample log (≤10 lines):**
```
nodetable: size=2
pkt tx kind=BEACON seq=12 t_ms=45000
pkt rx kind=BEACON seq=8 from=42 rssi=-65 t_ms=45100
peer shortId=42 ageS=2 grey=0 seq=8 rssi=-65 posAgeS=1
pkt tx kind=BEACON seq=13 t_ms=48000
```

- `pio run -e devkit_e220_oled_gnss` ✅
- `pio test -e test_native` ✅ (37 tests)
