### PR TITLE
FW: Instrumentation v2 — subtype logs and tail skip reasons

### DIFF
--- a/firmware/src/app/m1_runtime.cpp
+++ b/firmware/src/app/m1_runtime.cpp
@@ -12,6 +12,20 @@ constexpr uint8_t kGeoBeaconMsgType = protocol::kGeoBeaconMsgType;
 constexpr uint32_t kSenseTimeoutMs = 20U;
 constexpr size_t kMaxRxPerTick = 4;
 
+const char* packet_log_type_str(domain::PacketLogType t) {
+  switch (t) {
+    case domain::PacketLogType::CORE: return "CORE";
+    case domain::PacketLogType::TAIL1: return "TAIL1";
+    case domain::PacketLogType::TAIL2: return "TAIL2";
+    case domain::PacketLogType::ALIVE: return "ALIVE";
+  }
+  return "?";
+}
+
+bool is_tail_type(domain::PacketLogType t) {
+  return t == domain::PacketLogType::TAIL1 || t == domain::PacketLogType::TAIL2;
+}
+
 } // namespace
 
 void M1Runtime::init(uint64_t self_id,
@@ -144,13 +158,15 @@ void M1Runtime::log_peer_dump(uint32_t now_ms) {
 void M1Runtime::handle_tx(uint32_t now_ms) {
   if (!send_policy_.has_pending()) {
     size_t out_len = 0;
-    domain::BeaconSubtype tx_subtype = domain::BeaconSubtype::CORE;
+    domain::PacketLogType tx_type = domain::PacketLogType::CORE;
+    uint16_t tx_core_seq = 0;
     if (!beacon_logic_.build_tx(now_ms, self_fields_, pending_payload_, sizeof(pending_payload_),
-                                &out_len, &tx_subtype)) {
+                                &out_len, &tx_type, &tx_core_seq)) {
       return;
     }
     pending_len_ = out_len;
-    last_tx_subtype_ = tx_subtype;
+    last_tx_type_ = tx_type;
+    last_tx_core_seq_ = tx_core_seq;
     send_policy_.on_payload_built(now_ms);
   }
 
@@ -163,9 +179,15 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
     if (result.state == ChannelSenseState::BUSY || result.state == ChannelSenseState::ERROR) {
       send_policy_.on_channel_busy(now_ms);
       if (instrumentation_log_fn_ && instrumentation_ctx_) {
-        char line[64];
-        std::snprintf(line, sizeof(line), "pkt drop reason=CHANNEL_BUSY t_ms=%lu",
-                      static_cast<unsigned long>(now_ms));
+        char line[96];
+        if (is_tail_type(last_tx_type_)) {
+          std::snprintf(line, sizeof(line), "pkt drop t_ms=%lu type=%s reason=CHANNEL_BUSY core_seq=%u",
+                        static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
+                        static_cast<unsigned>(last_tx_core_seq_));
+        } else {
+          std::snprintf(line, sizeof(line), "pkt drop t_ms=%lu type=%s reason=CHANNEL_BUSY",
+                        static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_));
+        }
         instrumentation_log_fn_(line, instrumentation_ctx_);
       }
       log_event(now_ms, domain::LogEventId::RADIO_TX_ERR, domain::LogLevel::kWarn, &kGeoBeaconMsgType,
@@ -182,21 +204,31 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
     stats_.tx_count++;
     stats_.last_tx_ms = now_ms;
     if (instrumentation_log_fn_ && instrumentation_ctx_) {
-      const char* sub = (last_tx_subtype_ == domain::BeaconSubtype::CORE) ? "CORE" : "ALIVE";
-      char line[72];
-      std::snprintf(line, sizeof(line), "pkt tx subtype=%s seq=%u t_ms=%lu",
-                    sub, static_cast<unsigned>(stats_.last_seq),
-                    static_cast<unsigned long>(now_ms));
+      char line[96];
+      if (is_tail_type(last_tx_type_)) {
+        std::snprintf(line, sizeof(line), "pkt tx t_ms=%lu type=%s seq=%u core_seq=%u",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
+                      static_cast<unsigned>(stats_.last_seq), static_cast<unsigned>(last_tx_core_seq_));
+      } else {
+        std::snprintf(line, sizeof(line), "pkt tx t_ms=%lu type=%s seq=%u",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
+                      static_cast<unsigned>(stats_.last_seq));
+      }
       instrumentation_log_fn_(line, instrumentation_ctx_);
     }
     log_event(now_ms, domain::LogEventId::RADIO_TX_OK, domain::LogLevel::kInfo, &kGeoBeaconMsgType, 1);
     pending_len_ = 0;
   } else {
     if (instrumentation_log_fn_ && instrumentation_ctx_) {
-      const char* sub = (last_tx_subtype_ == domain::BeaconSubtype::CORE) ? "CORE" : "ALIVE";
-      char line[72];
-      std::snprintf(line, sizeof(line), "pkt drop subtype=%s reason=SEND_FAIL t_ms=%lu",
-                    sub, static_cast<unsigned long>(now_ms));
+      char line[96];
+      if (is_tail_type(last_tx_type_)) {
+        std::snprintf(line, sizeof(line), "pkt drop t_ms=%lu type=%s reason=SEND_FAIL core_seq=%u",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
+                      static_cast<unsigned>(last_tx_core_seq_));
+      } else {
+        std::snprintf(line, sizeof(line), "pkt drop t_ms=%lu type=%s reason=SEND_FAIL",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_));
+      }
       instrumentation_log_fn_(line, instrumentation_ctx_);
     }
     log_event(now_ms, domain::LogEventId::RADIO_TX_ERR, domain::LogLevel::kWarn, &kGeoBeaconMsgType, 1);
@@ -223,18 +255,25 @@ void M1Runtime::handle_rx(uint32_t now_ms) {
     uint64_t rx_node_id = 0;
     uint16_t rx_seq = 0;
     bool rx_pos_valid = false;
+    domain::PacketLogType rx_type = domain::PacketLogType::CORE;
+    uint16_t rx_core_seq = 0;
     const bool updated = beacon_logic_.on_rx(now_ms, payload, out_len, stats_.last_rssi_dbm,
-                                             node_table_, &rx_node_id, &rx_seq, &rx_pos_valid);
+                                             node_table_, &rx_node_id, &rx_seq, &rx_pos_valid,
+                                             &rx_type, &rx_core_seq);
     if (instrumentation_log_fn_ && instrumentation_ctx_) {
-      const char* sub = rx_pos_valid ? "CORE" : "ALIVE";
       const uint16_t from_short = domain::NodeTable::compute_short_id(rx_node_id);
-      char line[88];
-      std::snprintf(line, sizeof(line), "pkt rx subtype=%s seq=%u from=%u rssi=%d t_ms=%lu",
-                    sub,
-                    static_cast<unsigned>(rx_seq),
-                    static_cast<unsigned>(from_short),
-                    static_cast<int>(stats_.last_rssi_dbm),
-                    static_cast<unsigned long>(now_ms));
+      char line[100];
+      if (is_tail_type(rx_type)) {
+        std::snprintf(line, sizeof(line), "pkt rx t_ms=%lu type=%s seq=%u core_seq=%u from=%u rssi=%d",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(rx_type),
+                      static_cast<unsigned>(rx_seq), static_cast<unsigned>(rx_core_seq),
+                      static_cast<unsigned>(from_short), static_cast<int>(stats_.last_rssi_dbm));
+      } else {
+        std::snprintf(line, sizeof(line), "pkt rx t_ms=%lu type=%s seq=%u from=%u rssi=%d",
+                      static_cast<unsigned long>(now_ms), packet_log_type_str(rx_type),
+                      static_cast<unsigned>(rx_seq), static_cast<unsigned>(from_short),
+                      static_cast<int>(stats_.last_rssi_dbm));
+      }
       instrumentation_log_fn_(line, instrumentation_ctx_);
     }
     log_event(now_ms, domain::LogEventId::RADIO_RX_OK, domain::LogLevel::kInfo, &kGeoBeaconMsgType, 1);

--- a/firmware/src/app/m1_runtime.h
+++ b/firmware/src/app/m1_runtime.h
@@ -78,7 +78,8 @@ class M1Runtime {
   RadioSmokeStats stats_{};
   uint8_t pending_payload_[protocol::kGeoBeaconSize] = {};
   size_t pending_len_ = 0;
-  domain::BeaconSubtype last_tx_subtype_ = domain::BeaconSubtype::CORE;
+  domain::PacketLogType last_tx_type_ = domain::PacketLogType::CORE;
+  uint16_t last_tx_core_seq_ = 0;
 
   void (*instrumentation_log_fn_)(const char* line, void* ctx) = nullptr;
   void* instrumentation_ctx_ = nullptr;

--- a/firmware/src/domain/beacon_logic.h
+++ b/firmware/src/domain/beacon_logic.h
@@ -9,10 +9,12 @@
 namespace naviga {
 namespace domain {
 
-/** Subtype for instrumentation: current protocol has single on-air type; we derive CORE vs ALIVE from intent/pos_valid. */
-enum class BeaconSubtype {
-  CORE,   // position-bearing (pos_valid)
-  ALIVE,  // alive-only (no fix or max_silence send)
+/** Packet type for instrumentation logs. On-air we have a single format; we log CORE/ALIVE from intent/pos_valid. TAIL1/TAIL2 reserved for when tail packets exist. */
+enum class PacketLogType {
+  CORE,
+  TAIL1,
+  TAIL2,
+  ALIVE,
 };
 
 class BeaconLogic {
@@ -27,7 +29,8 @@ class BeaconLogic {
                 uint8_t* out,
                 size_t out_cap,
                 size_t* out_len,
-                BeaconSubtype* out_subtype = nullptr);
+                PacketLogType* out_type = nullptr,
+                uint16_t* out_core_seq = nullptr);
 
   bool on_rx(uint32_t now_ms,
              const uint8_t* payload,
@@ -36,7 +39,9 @@ class BeaconLogic {
              NodeTable& table,
              uint64_t* out_node_id = nullptr,
              uint16_t* out_seq = nullptr,
-             bool* out_pos_valid = nullptr);
+             bool* out_pos_valid = nullptr,
+             PacketLogType* out_type = nullptr,
+             uint16_t* out_core_seq = nullptr);
 
   uint16_t seq() const {
     return seq_;


### PR DESCRIPTION
Closes #274.

Adds instrumentation v2: **type** (CORE / TAIL1 / TAIL2 / ALIVE) in pkt tx/rx, **core_seq** for tail packets, and **pkt drop** with type + reason.

- **pkt tx:** `t_ms=... type=CORE|ALIVE seq=...`; for tail (when implemented): `type=TAIL1|TAIL2 seq=... core_seq=...`
- **pkt rx:** `t_ms=... type=CORE|ALIVE seq=... from=... rssi=...`; for tail: `type=TAIL1|TAIL2 seq=... core_seq=... from=... rssi=...`
- **pkt drop:** `t_ms=... type=CORE|TAIL1|TAIL2|ALIVE reason=CHANNEL_BUSY|SEND_FAIL`; for tail: `... core_seq=...` (reasons: CHANNEL_BUSY, SEND_FAIL; reserved: NEW_CORE_PREEMPT, WINDOW_EXPIRED, QUEUE_FULL).

No on-air or NodeTable changes. Current encoding has single packet format; only CORE and ALIVE appear in logs until tail packets exist.

Refs: #224, #269, #270, #275.

**Sample log (≤12 lines):**
```
nodetable: size=2
pkt tx t_ms=45000 type=CORE seq=8
pkt rx t_ms=45100 type=CORE seq=4 from=61542 rssi=-20
peer shortId=61542 ageS=2 grey=0 seq=4 rssi=-20 posAgeS=1
pkt tx t_ms=48000 type=ALIVE seq=9
pkt rx t_ms=48150 type=CORE seq=5 from=61542 rssi=-19
pkt tx t_ms=49000 type=TAIL1 seq=2 core_seq=8
pkt drop t_ms=51000 type=CORE reason=CHANNEL_BUSY
```

(TAIL line appears when tail packets are implemented; drop shows type= and reason=.)

- `pio run -e devkit_e220_oled_gnss` ✅
- `pio test -e test_native` ✅ (37 tests)
