### PR TITLE
#280 RX semantics v0 for NodeTable (duplicate/ooo/seq16 wrap)

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -48,3 +48,10 @@ build_flags =
 build_src_filter =
   -<*>
   +<platform/ble_transport_core.cpp>
+
+[env:test_native_nodetable]
+platform = native
+test_framework = unity
+test_build_src = false
+build_flags =
+  -std=gnu++11


### PR DESCRIPTION
Closes #280. Refs #277, #224.

## Summary
Implements RX semantics v0 in NodeTable per [rx_semantics_v0](docs/product/areas/nodetable/policy/rx_semantics_v0.md): duplicate (same seq16) → refresh lastRxAt + link metrics only; out-of-order (older seq16) → do not overwrite position/telemetry; seq16 wrap handled for ordering.

## Changes
- **firmware/src/domain/node_table.cpp**: `seq16_order(incoming, last)` with wrap (Same / Newer / Older); `upsert_remote` branches: Newer → full update; Same → last_seen_ms + last_rx_rssi only; Older → last_seen_ms + last_rx_rssi only.
- **firmware/test/test_node_table_domain/test_node_table_domain.cpp**: Tests for duplicate same seq (position unchanged), ooo older seq (position unchanged), newer seq (position updated), seq16 wrap newer/older. Fix Unity macro in test_collision_flagging (TEST_ASSERT_TRUE(id != 0)).
- **firmware/platformio.ini**: `test_native_nodetable` env to run node_table tests natively (`pio test -e test_native_nodetable -f test_node_table_domain`).

No on-air format or protocol changes. No new persisted fields.

## DoD
- [x] Duplicate: same nodeId+seq16 → lastRxAt + rssi only; position unchanged
- [x] Ooo: older seq16 → no overwrite of position/seq; lastRxAt + rssi updated
- [x] seq16 wrap: ordering consistent (wrap-newer and wrap-older tests)
- [x] Unit tests; `pio test -e test_native_nodetable -f test_node_table_domain` passes
- [x] `pio run -e devkit_e220_oled_gnss` builds
