### PR TITLE
#288 GNSS scenario emulator v0 (shell override)

### DIFF
--- a/docs/product/areas/firmware/policy/gnss_scenario_emulator_v0.md
+++ b/docs/product/areas/firmware/policy/gnss_scenario_emulator_v0.md
@@ -1,0 +1,67 @@
+# GNSS Scenario Emulator v0 (policy)
+
+**Status:** Policy (design + V0 implementation).  
+**Issue:** [#288](https://github.com/AlexanderTsarkov/naviga-app/issues/288)  
+**Gate:** #277
+
+---
+
+## 1) Goal
+
+Provide **deterministic GNSS behavior** for bench and CI-style acceptance tests: scripted states (NO_FIX, FIX_NO_MOVE, FIX_MOVE, FLAP), controllable via provisioning shell, repeatable. Enables proving cadence rules (#281: minInterval, maxSilence, minDistance, CORE vs ALIVE) under controlled scenarios without moving hardware.
+
+## 2) Non-goals
+
+- No hardware GNSS simulator.
+- No mesh/JOIN/CAD/LBT.
+- No on-air protocol or codec changes.
+- No BLE/mobile changes.
+- V0 only: minimal shell-driven injection; no full scenario runner or UART replay in this version.
+
+## 3) Design (V0)
+
+- **Override layer:** When enabled, the app uses an injected `GnssSnapshot` (pos_valid, lat_e7, lon_e7, last_fix_ms) instead of calling the real GNSS provider. Default: **disabled** (real GNSS).
+- **Control:** Provisioning shell commands over serial.
+- **States:** NO_FIX (pos_valid=false), FIX (pos_valid=true, fixed lat/lon), FIX_MOVE (increment position with `move`). FLAP (optional V0: manual toggle or future extension).
+
+## 4) Commands
+
+| Command | Effect |
+|--------|--------|
+| `gnss off` | Disable override; use real GNSS. |
+| `gnss nofix` | Override: NO_FIX (pos_valid=false). |
+| `gnss fix <lat_e7> <lon_e7>` | Override: FIX at given position (e.g. `571844000 383663000`). |
+| `gnss move <dlat_e7> <dlon_e7>` | Increment override position (e.g. `1000 0` ≈ ~11 m north). |
+
+Coordinates in **e7** (degrees × 10^7). Response confirms mode, e.g. `OK; gnss override NO_FIX`.
+
+## 5) Log output
+
+When override is active, the app logs periodically (e.g. every 5 s):  
+`GNSS override: NO_FIX` or `GNSS override: FIX lat_e7=... lon_e7=...`.
+
+## 6) Example (repeatable script)
+
+```
+gnss nofix
+debug on
+# wait > maxSilence (e.g. 35 s for role 0) → expect ALIVE at maxSilence
+# then:
+gnss fix 571844000 383663000
+# wait min_interval (e.g. 18 s) with no move → no CORE (NO_SEND)
+gnss move 3000000 0
+# position commit → next TX can be CORE
+```
+
+## 7) DoD
+
+- Run script produces repeatable logs.
+- Scenario 1: NO_FIX for > maxSilence ⇒ ALIVE at maxSilence.
+- Scenario 2: FIX_NO_MOVE (no movement) ⇒ NO_SEND until maxSilence ⇒ then CORE (or ALIVE if no fix at that moment per policy).
+- Scenario 3: FIX_MOVE ⇒ commits happen and CORE cadence follows role gating.
+
+## 8) References
+
+- field_cadence_v0, role_profiles_policy_v0
+- #281 (role cadence wiring)
+- provisioning_interface_v0 (shell)

--- a/firmware/src/app/app_services.h
+++ b/firmware/src/app/app_services.h
@@ -4,6 +4,7 @@
 
 #include "app/m1_runtime.h"
 #include "domain/logger.h"
+#include "services/gnss_scenario_override.h"
 #include "services/oled_status.h"
 #include "services/radio_smoke_service.h"
 
@@ -25,6 +26,7 @@ class AppServices {
   uint32_t last_heartbeat_ms_ = 0;
   uint32_t last_summary_ms_ = 0;
   uint32_t last_peer_dump_ms_ = 0;
+  uint32_t last_gnss_override_log_ms_ = 0;
   bool fix_logged_ = false;
   bool instrumentation_enabled_ = false;
   RadioRole role_ = RadioRole::RESP;
@@ -36,6 +38,7 @@ class AppServices {
   M1Runtime runtime_;
   OledStatus oled_;
   ProvisioningAdapter* provisioning_ = nullptr;
+  GnssScenarioOverride gnss_override_;
 };
 
 }  // namespace naviga

--- a/firmware/src/platform/provisioning_adapter.cpp
+++ b/firmware/src/platform/provisioning_adapter.cpp
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <cstring>
 
+#include "services/gnss_scenario_override.h"
+
 #ifdef ESP32
 #include <esp_system.h>
 #endif
@@ -15,6 +17,10 @@ void ProvisioningAdapter::set_radio_boot_info(int result_enum, const char* messa
 
 void ProvisioningAdapter::set_instrumentation_flag(bool* flag) {
   shell_.set_instrumentation_flag(flag);
+}
+
+void ProvisioningAdapter::set_gnss_override(GnssScenarioOverride* ptr) {
+  shell_.set_gnss_override(ptr);
 }
 
 void ProvisioningAdapter::tick(uint32_t /*now_ms*/) {

--- a/firmware/src/platform/provisioning_adapter.h
+++ b/firmware/src/platform/provisioning_adapter.h
@@ -19,6 +19,9 @@ class ProvisioningAdapter {
   /** Optional: enable "debug on/off" in shell to toggle instrumentation (e.g. packet/peer logs). */
   void set_instrumentation_flag(bool* flag);
 
+  /** Optional: enable "gnss off|nofix|fix|move" scenario override in shell (#288). */
+  void set_gnss_override(class GnssScenarioOverride* ptr);
+
   /** Read one line (non-blocking), handle via shell, print response; at most one line per call. */
   void tick(uint32_t now_ms);
 

--- a/firmware/src/services/gnss_scenario_override.cpp
+++ b/firmware/src/services/gnss_scenario_override.cpp
@@ -1,0 +1,37 @@
+#include "services/gnss_scenario_override.h"
+
+namespace naviga {
+
+void GnssScenarioOverride::set_nofix() {
+  enabled_ = true;
+  snapshot_.fix_state = GNSSFixState::NO_FIX;
+  snapshot_.pos_valid = false;
+  snapshot_.lat_e7 = 0;
+  snapshot_.lon_e7 = 0;
+  snapshot_.last_fix_ms = 0;
+}
+
+void GnssScenarioOverride::set_fix(int32_t lat_e7, int32_t lon_e7) {
+  enabled_ = true;
+  snapshot_.fix_state = GNSSFixState::FIX_3D;
+  snapshot_.pos_valid = true;
+  snapshot_.lat_e7 = lat_e7;
+  snapshot_.lon_e7 = lon_e7;
+  snapshot_.last_fix_ms = 0;  // set at get_snapshot_if_active to now_ms
+}
+
+void GnssScenarioOverride::move(int32_t dlat_e7, int32_t dlon_e7) {
+  if (!enabled_) return;
+  snapshot_.lat_e7 += dlat_e7;
+  snapshot_.lon_e7 += dlon_e7;
+}
+
+bool GnssScenarioOverride::get_snapshot_if_active(GnssSnapshot* out, uint32_t now_ms) const {
+  if (!enabled_ || !out) return false;
+  *out = snapshot_;
+  if (out->pos_valid)
+    out->last_fix_ms = now_ms;  // position appears fresh
+  return true;
+}
+
+}  // namespace naviga

--- a/firmware/src/services/gnss_scenario_override.h
+++ b/firmware/src/services/gnss_scenario_override.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+#include "naviga/hal/interfaces.h"
+
+namespace naviga {
+
+/**
+ * GNSS scenario override for deterministic bench tests (#288).
+ * When enabled, get_snapshot_if_active() returns injected state instead of real GNSS.
+ * Default: disabled (use real GNSS).
+ */
+class GnssScenarioOverride {
+ public:
+  GnssScenarioOverride() = default;
+
+  void set_off() { enabled_ = false; }
+  void set_nofix();
+  void set_fix(int32_t lat_e7, int32_t lon_e7);
+  void move(int32_t dlat_e7, int32_t dlon_e7);
+
+  /** If enabled, write current override snapshot to *out (last_fix_ms set to now_ms when pos_valid) and return true. */
+  bool get_snapshot_if_active(GnssSnapshot* out, uint32_t now_ms) const;
+
+  bool enabled() const { return enabled_; }
+
+ private:
+  bool enabled_ = false;
+  GnssSnapshot snapshot_{};
+};
+
+}  // namespace naviga

--- a/firmware/src/services/provisioning_shell.h
+++ b/firmware/src/services/provisioning_shell.h
@@ -21,6 +21,9 @@ class ProvisioningShell {
   /** Optional: when set, "debug on" / "debug off" toggle *flag (e.g. instrumentation logging). */
   void set_instrumentation_flag(bool* flag) { instrumentation_flag_ = flag; }
 
+  /** Optional: when set, "gnss off|nofix|fix <lat_e7> <lon_e7>|move <dlat_e7> <dlon_e7>" control scenario override (#288). */
+  void set_gnss_override(class GnssScenarioOverride* ptr) { gnss_override_ = ptr; }
+
   /**
    * Parse and execute one command line. Fills out_response with reply text (null-terminated).
    * If the command is "reboot", sets *reboot_requested = true (caller must perform restart).
@@ -37,6 +40,7 @@ class ProvisioningShell {
   int radio_boot_result_ = 0;
   char radio_boot_message_[48] = {};
   bool* instrumentation_flag_ = nullptr;
+  class GnssScenarioOverride* gnss_override_ = nullptr;
 };
 
 }  // namespace naviga


### PR DESCRIPTION
Closes #288. Refs #277.

**Summary:** GNSS scenario emulator v0: shell-driven override for deterministic bench. When enabled, app uses injected GnssSnapshot (NO_FIX / FIX at lat_e7,lon_e7 / move) instead of real GNSS. Default: off (real GNSS).

**Changes:** gnss_scenario_override service, provisioning shell commands (gnss off|nofix|fix|move), app_services wire + log; docs/product/areas/firmware/policy/gnss_scenario_emulator_v0.md.

**Quality:** No protocol changes. Build + tests OK. Bench evidence in _working/hw_tests/2026-02-23_s02_288/.

Made with [Cursor](https://cursor.com)