### PR TITLE
#289 Cadence from current profile record in flash (registry-driven)

### DIFF
--- a/_working/S02_289_evidence_procedure.md
+++ b/_working/S02_289_evidence_procedure.md
@@ -1,0 +1,38 @@
+# #289 Evidence: Cadence from registry (profile record in flash)
+
+**Issue:** #289 Wire cadence parameters from current profile record in flash  
+**DoD:** Change the current profile record in flash (via provisioning) and observe changed TX cadence **without reflashing firmware**.
+
+## Storage location
+
+- **Namespace:** NVS `naviga`
+- **Keys:** `role_interval_s` (uint32), `role_silence_10s` (uint32), `role_dist_m` (float)
+- **API:** `load_current_role_profile_record()`, `save_current_role_profile_record()`, `get_ootb_role_profile(role_id)` (platform/naviga_storage.h, role_profile_ootb.cpp)
+
+## Procedure to prove DoD
+
+1. **Flash** one device with firmware that includes #289 (registry-driven cadence).
+2. **Provision** role and ensure profile record exists: e.g. `set role 0` then `reboot`. After boot, log line should show `Applied: interval_s=18 ... cadence=registry`.
+3. **Observe baseline:** With `gnss fix <lat> <lon>` and periodic `gnss move` (e.g. every 10s), capture serial log; note CORE TX interval (e.g. ~18 s for Person).
+4. **Change record without reflashing:** Over serial send:
+   - `profile interval 30`  (or `profile silence 9`, `profile distance 25` as needed)
+   - `get profile` → confirm `interval_s=30` (or other field).
+   - `reboot`
+5. **Observe new cadence:** After reboot, log should show `Applied: interval_s=30 ... cadence=registry`. With same GNSS move pattern, CORE TX interval should be ~30 s (no code change).
+6. **Optional:** `set role 1` then `reboot` restores OOTB Dog profile (9s/3/15m) into the record; next boot uses those values.
+
+## Shell commands (provisioning)
+
+| Command | Effect |
+|---------|--------|
+| `get profile` | Print current profile record (interval_s, silence_10s, dist_m, valid). |
+| `profile interval <sec>` | Set minIntervalSec (1–3600); reboot to apply. |
+| `profile silence <10s>` | Set maxSilence10s (1–255); reboot to apply. |
+| `profile distance <m>` | Set minDisplacementM (0–1000); reboot to apply. |
+| `set role 0\|1\|2` | Set role pointer and write OOTB profile (Person/Dog/Infra) into the record; reboot to apply. |
+
+Constraint: `maxSilence >= 3 * minInterval` (enforced on set).
+
+## Fallback
+
+If no profile record in NVS or stored values invalid (range or invariant), boot uses **default** (Person 18/9/25) and writes it back to NVS so next boot has a valid record.

--- a/firmware/src/platform/naviga_storage.h
+++ b/firmware/src/platform/naviga_storage.h
@@ -21,6 +21,36 @@ struct PersistedPointers {
 };
 
 /**
+ * Current role profile record (cadence params) stored in flash (#289).
+ * Resolved via persisted "current" record; fallback to default when missing/invalid.
+ */
+struct RoleProfileRecord {
+  uint16_t min_interval_sec = 18;
+  uint8_t max_silence_10s = 9;
+  float min_displacement_m = 25.0f;
+};
+
+/**
+ * Load the current role profile record from NVS.
+ * If missing or invalid, out is filled with default (Person) and *valid = false.
+ * Returns true if NVS was read; valid is set to true only when stored values pass validation.
+ */
+bool load_current_role_profile_record(RoleProfileRecord* out, bool* valid);
+
+/**
+ * Save the current role profile record to NVS.
+ * Caller should ensure values satisfy role_profiles_policy_v0 (e.g. maxSilence >= 3*minInterval).
+ * Returns true on success.
+ */
+bool save_current_role_profile_record(const RoleProfileRecord& record);
+
+/**
+ * Fill record with OOTB defaults for the given role id (0=Person, 1=Dog, 2=Infra).
+ * Used when "set role X" persists the profile and when falling back to default.
+ */
+void get_ootb_role_profile(uint32_t role_id, RoleProfileRecord* out);
+
+/**
  * Load persisted pointers from NVS (namespace "naviga").
  * Returns true if NVS was opened and read; out is filled (missing keys leave has_* false).
  */
@@ -36,7 +66,7 @@ bool save_pointers(uint32_t current_role_id,
                    uint32_t previous_radio_profile_id);
 
 /**
- * Clear all role/radio pointer keys (factory reset of pointers only).
+ * Clear all role/radio pointer keys and reset current role profile record to default (Person).
  * Returns true on success.
  */
 bool factory_reset_pointers();

--- a/firmware/src/platform/role_profile_ootb.cpp
+++ b/firmware/src/platform/role_profile_ootb.cpp
@@ -1,0 +1,31 @@
+#include "platform/naviga_storage.h"
+
+namespace naviga {
+
+void get_ootb_role_profile(uint32_t role_id, RoleProfileRecord* out) {
+  if (!out) return;
+  switch (role_id) {
+    case 0:
+      out->min_interval_sec = 18;
+      out->max_silence_10s = 9;
+      out->min_displacement_m = 25.0f;
+      break;
+    case 1:
+      out->min_interval_sec = 9;
+      out->max_silence_10s = 3;
+      out->min_displacement_m = 15.0f;
+      break;
+    case 2:
+      out->min_interval_sec = 360;
+      out->max_silence_10s = 255;
+      out->min_displacement_m = 100.0f;
+      break;
+    default:
+      out->min_interval_sec = 18;
+      out->max_silence_10s = 9;
+      out->min_displacement_m = 25.0f;
+      break;
+  }
+}
+
+}  // namespace naviga

--- a/firmware/test/test_role_profile_registry/test_role_profile_registry.cpp
+++ b/firmware/test/test_role_profile_registry/test_role_profile_registry.cpp
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for #289: role profile record and OOTB defaults.
+ * Tests get_ootb_role_profile (no NVS); fallback behavior is tested on device.
+ */
+#include <unity.h>
+
+#include <cstdint>
+
+#include "../../src/platform/naviga_storage.h"
+#include "../../src/platform/role_profile_ootb.cpp"
+
+using naviga::RoleProfileRecord;
+using naviga::get_ootb_role_profile;
+
+namespace {
+
+void expect_person(const RoleProfileRecord& r) {
+  TEST_ASSERT_EQUAL_UINT16(18, r.min_interval_sec);
+  TEST_ASSERT_EQUAL_UINT8(9, r.max_silence_10s);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 25.0f, r.min_displacement_m);
+}
+
+void expect_dog(const RoleProfileRecord& r) {
+  TEST_ASSERT_EQUAL_UINT16(9, r.min_interval_sec);
+  TEST_ASSERT_EQUAL_UINT8(3, r.max_silence_10s);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 15.0f, r.min_displacement_m);
+}
+
+void expect_infra(const RoleProfileRecord& r) {
+  TEST_ASSERT_EQUAL_UINT16(360, r.min_interval_sec);
+  TEST_ASSERT_EQUAL_UINT8(255, r.max_silence_10s);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 100.0f, r.min_displacement_m);
+}
+
+}  // namespace
+
+void test_ootb_role_0_person() {
+  RoleProfileRecord out{};
+  get_ootb_role_profile(0, &out);
+  expect_person(out);
+}
+
+void test_ootb_role_1_dog() {
+  RoleProfileRecord out{};
+  get_ootb_role_profile(1, &out);
+  expect_dog(out);
+}
+
+void test_ootb_role_2_infra() {
+  RoleProfileRecord out{};
+  get_ootb_role_profile(2, &out);
+  expect_infra(out);
+}
+
+void test_ootb_role_invalid_fallback_default() {
+  RoleProfileRecord out{};
+  get_ootb_role_profile(99, &out);
+  expect_person(out);
+}
+
+void test_ootb_null_out_no_crash() {
+  get_ootb_role_profile(0, nullptr);
+  get_ootb_role_profile(1, nullptr);
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_ootb_role_0_person);
+  RUN_TEST(test_ootb_role_1_dog);
+  RUN_TEST(test_ootb_role_2_infra);
+  RUN_TEST(test_ootb_role_invalid_fallback_default);
+  RUN_TEST(test_ootb_null_out_no_crash);
+  return UNITY_END();
+}


### PR DESCRIPTION
Closes #289. Refs #277, #224.

## Summary

- **Runtime cadence** (minInterval, maxSilence, minDistance) is now sourced from the **current role profile record** stored in NVS (registry), resolved via persisted pointers; no hardcoded role-ID tables for cadence.
- **Storage:** NVS namespace `naviga`, keys `role_interval_s`, `role_silence_10s`, `role_dist_m`. Validation: interval 1–3600, silence 1–255, distance 0–1000, invariant `maxSilence >= 3*minInterval`.
- **Phase B:** Loads profile via `load_current_role_profile_record()`; if missing/invalid → OOTB by effective_role_id, then persist. Log marker `cadence=registry`.
- **Shell:** `set role 0|1|2` seeds record from OOTB; `get profile`; `profile interval|silence|distance <val>` (reboot to apply). `factory_reset_pointers()` seeds default (Person) record.
- **Tests:** `test_role_profile_registry` (native): OOTB 0/1/2, fallback for invalid role_id, nullptr safety.

## Evidence

- Procedure to prove DoD (change record in flash → observe changed cadence without reflashing): **`_working/S02_289_evidence_procedure.md`**.

## Test commands

```bash
pio run -e devkit_e220_oled_gnss
pio test -e test_native_nodetable -f test_beacon_logic -f test_role_profile_registry
```

## Non-goals (unchanged)

- No on-air protocol/codec changes (#282–#285).
- No mesh/JOIN/CAD/LBT.
- No legacy BLE. No UI/mobile.

## Files

- `firmware/src/platform/naviga_storage.h` — RoleProfileRecord, load/save/get_ootb API
- `firmware/src/platform/naviga_storage.cpp` — NVS load/save, validation, factory reset
- `firmware/src/platform/role_profile_ootb.cpp` — OOTB table (no NVS)
- `firmware/src/app/app_services.cpp` — Phase B wired to registry
- `firmware/src/services/provisioning_shell.cpp` — get profile, profile interval/silence/distance, set role seeds record
- `firmware/test/test_role_profile_registry/` — unit tests
- `_working/S02_289_evidence_procedure.md` — evidence procedure
