### PR TITLE
#282 Canon Core/Alive encodings (19B/11B) + BeaconLogic TX/RX

### DIFF
--- a/firmware/protocol/geo_beacon_codec.cpp
+++ b/firmware/protocol/geo_beacon_codec.cpp
@@ -23,41 +23,30 @@ void write_u32_le(uint8_t* dst, uint32_t value) {
 }
 
 void write_u64_le(uint8_t* dst, uint64_t value) {
-  dst[0] = static_cast<uint8_t>(value & 0xFF);
-  dst[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
-  dst[2] = static_cast<uint8_t>((value >> 16) & 0xFF);
-  dst[3] = static_cast<uint8_t>((value >> 24) & 0xFF);
-  dst[4] = static_cast<uint8_t>((value >> 32) & 0xFF);
-  dst[5] = static_cast<uint8_t>((value >> 40) & 0xFF);
-  dst[6] = static_cast<uint8_t>((value >> 48) & 0xFF);
-  dst[7] = static_cast<uint8_t>((value >> 56) & 0xFF);
-}
-
-uint16_t read_u16_le(const uint8_t* src) {
-  return static_cast<uint16_t>(src[0]) |
-         static_cast<uint16_t>(src[1]) << 8;
-}
-
-uint32_t read_u32_le(const uint8_t* src) {
-  return static_cast<uint32_t>(src[0]) |
-         static_cast<uint32_t>(src[1]) << 8 |
-         static_cast<uint32_t>(src[2]) << 16 |
-         static_cast<uint32_t>(src[3]) << 24;
-}
-
-uint64_t read_u64_le(const uint8_t* src) {
-  return static_cast<uint64_t>(src[0]) |
-         static_cast<uint64_t>(src[1]) << 8 |
-         static_cast<uint64_t>(src[2]) << 16 |
-         static_cast<uint64_t>(src[3]) << 24 |
-         static_cast<uint64_t>(src[4]) << 32 |
-         static_cast<uint64_t>(src[5]) << 40 |
-         static_cast<uint64_t>(src[6]) << 48 |
-         static_cast<uint64_t>(src[7]) << 56;
+  for (int i = 0; i < 8; ++i) {
+    dst[i] = static_cast<uint8_t>((value >> (8 * i)) & 0xFF);
+  }
 }
 
 void write_i32_le(uint8_t* dst, int32_t value) {
   write_u32_le(dst, static_cast<uint32_t>(value));
+}
+
+uint16_t read_u16_le(const uint8_t* src) {
+  return static_cast<uint16_t>(src[0]) | (static_cast<uint16_t>(src[1]) << 8);
+}
+
+uint32_t read_u32_le(const uint8_t* src) {
+  return static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+         (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24);
+}
+
+uint64_t read_u64_le(const uint8_t* src) {
+  uint64_t v = 0;
+  for (int i = 0; i < 8; ++i) {
+    v |= static_cast<uint64_t>(src[i]) << (8 * i);
+  }
+  return v;
 }
 
 int32_t read_i32_le(const uint8_t* src) {
@@ -68,55 +57,80 @@ bool in_range_i32(int32_t value, int32_t min_value, int32_t max_value) {
   return value >= min_value && value <= max_value;
 }
 
-} // namespace
+}  // namespace
 
-size_t encode_geo_beacon(const GeoBeaconFields& fields, ByteSpan out) {
-  if (!out.data || out.size < kGeoBeaconSize) {
+// Core: payloadVersion(1) | nodeId(8) | seq16(2) | positionLat(4) | positionLon(4) = 19 B.
+size_t encode_core(const GeoBeaconFields& fields, ByteSpan out) {
+  if (!out.data || out.size < kCorePayloadSize) {
     return 0;
   }
-
-  out.data[0] = kGeoBeaconMsgType;
-  out.data[1] = kGeoBeaconVersion;
-  out.data[2] = 0;
-  write_u64_le(out.data + 3, fields.node_id);
-  out.data[11] = fields.pos_valid;
-  write_i32_le(out.data + 12, fields.lat_e7);
-  write_i32_le(out.data + 16, fields.lon_e7);
-  write_u16_le(out.data + 20, fields.pos_age_s);
-  write_u16_le(out.data + 22, fields.seq);
-
-  return kGeoBeaconSize;
+  out.data[0] = kBeaconVersion;
+  write_u64_le(out.data + 1, fields.node_id);
+  write_u16_le(out.data + 9, fields.seq);
+  write_i32_le(out.data + 11, fields.lat_e7);
+  write_i32_le(out.data + 15, fields.lon_e7);
+  return kCorePayloadSize;
 }
 
-DecodeError decode_geo_beacon(ConstByteSpan in, GeoBeaconFields* out) {
-  if (!in.data || !out || in.size < kGeoBeaconSize) {
+// Alive: payloadVersion(1) | nodeId(8) | seq16(2) = 11 B.
+size_t encode_alive(uint64_t node_id, uint16_t seq, ByteSpan out) {
+  if (!out.data || out.size < kAlivePayloadSize) {
+    return 0;
+  }
+  out.data[0] = kBeaconVersion;
+  write_u64_le(out.data + 1, node_id);
+  write_u16_le(out.data + 9, seq);
+  return kAlivePayloadSize;
+}
+
+DecodeError decode_core(ConstByteSpan in, GeoBeaconFields* out) {
+  if (!in.data || !out || in.size != kCorePayloadSize) {
     return DecodeError::ShortBuffer;
   }
-
-  if (in.data[0] != kGeoBeaconMsgType) {
-    return DecodeError::BadMsgType;
-  }
-
-  if (in.data[1] != kGeoBeaconVersion) {
+  if (in.data[0] != kBeaconVersion) {
     return DecodeError::BadVersion;
   }
-
-  out->node_id = read_u64_le(in.data + 3);
-  out->pos_valid = in.data[11];
-  out->lat_e7 = read_i32_le(in.data + 12);
-  out->lon_e7 = read_i32_le(in.data + 16);
-  out->pos_age_s = read_u16_le(in.data + 20);
-  out->seq = read_u16_le(in.data + 22);
-
-  if (out->pos_valid != 0) {
-    if (!in_range_i32(out->lat_e7, kLatMin, kLatMax) ||
-        !in_range_i32(out->lon_e7, kLonMin, kLonMax)) {
-      return DecodeError::InvalidRange;
-    }
+  out->node_id = read_u64_le(in.data + 1);
+  out->seq = read_u16_le(in.data + 9);
+  out->lat_e7 = read_i32_le(in.data + 11);
+  out->lon_e7 = read_i32_le(in.data + 15);
+  out->pos_valid = 1;
+  out->pos_age_s = 0;
+  if (!in_range_i32(out->lat_e7, kLatMin, kLatMax) ||
+      !in_range_i32(out->lon_e7, kLonMin, kLonMax)) {
+    return DecodeError::InvalidRange;
   }
-
   return DecodeError::Ok;
 }
 
-} // namespace protocol
-} // namespace naviga
+DecodeError decode_alive(ConstByteSpan in, GeoBeaconFields* out) {
+  if (!in.data || !out || in.size != kAlivePayloadSize) {
+    return DecodeError::ShortBuffer;
+  }
+  if (in.data[0] != kBeaconVersion) {
+    return DecodeError::BadVersion;
+  }
+  out->node_id = read_u64_le(in.data + 1);
+  out->seq = read_u16_le(in.data + 9);
+  out->pos_valid = 0;
+  out->lat_e7 = 0;
+  out->lon_e7 = 0;
+  out->pos_age_s = 0;
+  return DecodeError::Ok;
+}
+
+DecodeError decode_beacon(ConstByteSpan in, GeoBeaconFields* out) {
+  if (!in.data || !out) {
+    return DecodeError::ShortBuffer;
+  }
+  if (in.size == kCorePayloadSize) {
+    return decode_core(in, out);
+  }
+  if (in.size == kAlivePayloadSize) {
+    return decode_alive(in, out);
+  }
+  return DecodeError::BadMsgType;
+}
+
+}  // namespace protocol
+}  // namespace naviga

--- a/firmware/protocol/geo_beacon_codec.h
+++ b/firmware/protocol/geo_beacon_codec.h
@@ -6,12 +6,13 @@
 namespace naviga {
 namespace protocol {
 
+/** Decoded beacon fields (Core or Alive). For Alive, pos_valid=0 and lat_e7/lon_e7 unused. */
 struct GeoBeaconFields {
   uint64_t node_id;
   uint8_t pos_valid;
   int32_t lat_e7;
   int32_t lon_e7;
-  uint16_t pos_age_s;
+  uint16_t pos_age_s;  // Core: not in 19B canon; set 0 when decoded. Alive: N/A.
   uint16_t seq;
 };
 
@@ -33,12 +34,31 @@ struct ConstByteSpan {
   size_t size;
 };
 
-constexpr size_t kGeoBeaconSize = 24;
+// Canon (beacon_payload_encoding_v0, alive_packet_encoding_v0): Core 19B, Alive 11B.
+constexpr size_t kCorePayloadSize = 19;
+constexpr size_t kAlivePayloadSize = 11;
+constexpr uint8_t kBeaconVersion = 0x00;
+
+/** Max payload size for TX/RX buffers (Core is longer). */
+constexpr size_t kGeoBeaconSize = kCorePayloadSize;
+
+// Legacy alias for buffer sizing (same as Core).
 constexpr uint8_t kGeoBeaconMsgType = 0x01;
-constexpr uint8_t kGeoBeaconVersion = 1;
 
-size_t encode_geo_beacon(const GeoBeaconFields& fields, ByteSpan out);
-DecodeError decode_geo_beacon(ConstByteSpan in, GeoBeaconFields* out);
+/** Encode BeaconCore (19 B): version(1) | nodeId(8) | seq16(2) | positionLat(4) | positionLon(4). */
+size_t encode_core(const GeoBeaconFields& fields, ByteSpan out);
 
-} // namespace protocol
-} // namespace naviga
+/** Encode Alive (11 B): version(1) | nodeId(8) | seq16(2). */
+size_t encode_alive(uint64_t node_id, uint16_t seq, ByteSpan out);
+
+/** Decode BeaconCore (exactly 19 bytes). Fills pos_valid=1, lat, lon; pos_age_s=0. */
+DecodeError decode_core(ConstByteSpan in, GeoBeaconFields* out);
+
+/** Decode Alive (exactly 11 bytes). Fills node_id, seq; pos_valid=0, lat/lon=0, pos_age_s=0. */
+DecodeError decode_alive(ConstByteSpan in, GeoBeaconFields* out);
+
+/** Dispatch by length: 19 → decode_core, 11 → decode_alive; else error. */
+DecodeError decode_beacon(ConstByteSpan in, GeoBeaconFields* out);
+
+}  // namespace protocol
+}  // namespace naviga

--- a/firmware/test/test_beacon_logic/test_beacon_logic.cpp
+++ b/firmware/test/test_beacon_logic/test_beacon_logic.cpp
@@ -54,7 +54,7 @@ void test_tx_cadence() {
   TEST_ASSERT_EQUAL_UINT32(0, out_len);
 
   TEST_ASSERT_TRUE(logic.build_tx(1000, fields, buffer, sizeof(buffer), &out_len));
-  TEST_ASSERT_EQUAL_UINT32(24, out_len);
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kCorePayloadSize, out_len);
 }
 
 // Role-derived cadence (#281): max_silence_ms forces TX when min_interval is not yet reached.
@@ -78,12 +78,13 @@ void test_tx_max_silence_triggers_send() {
   TEST_ASSERT_EQUAL_UINT32(0, out_len);
 
   TEST_ASSERT_TRUE(logic.build_tx(10000, fields, buffer, sizeof(buffer), &out_len, &ptype));
-  TEST_ASSERT_EQUAL_UINT32(24, out_len);
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kCorePayloadSize, out_len);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::CORE), static_cast<int>(ptype));  // fix → CORE
 
-  // No fix at max_silence → ALIVE
+  // No fix at max_silence → ALIVE (11 B)
   fields.pos_valid = 0;
   TEST_ASSERT_TRUE(logic.build_tx(20000, fields, buffer, sizeof(buffer), &out_len, &ptype));
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kAlivePayloadSize, out_len);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::ALIVE), static_cast<int>(ptype));
 }
 
@@ -117,24 +118,23 @@ void test_tx_payload_correctness() {
   fields.lon_e7 = -456;
   fields.pos_age_s = 7;
 
-  uint8_t buffer[24] = {};
+  uint8_t buffer[32] = {};
   size_t out_len = 0;
   TEST_ASSERT_TRUE(logic.build_tx(10, fields, buffer, sizeof(buffer), &out_len));
-  TEST_ASSERT_EQUAL_UINT32(24, out_len);
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kCorePayloadSize, out_len);
 
   GeoBeaconFields decoded{};
   const auto err =
-      naviga::protocol::decode_geo_beacon(naviga::protocol::ConstByteSpan{buffer, out_len}, &decoded);
+      naviga::protocol::decode_beacon(naviga::protocol::ConstByteSpan{buffer, out_len}, &decoded);
   TEST_ASSERT_EQUAL(naviga::protocol::DecodeError::Ok, err);
   TEST_ASSERT_EQUAL_UINT64(fields.node_id, decoded.node_id);
-  TEST_ASSERT_EQUAL_UINT8(fields.pos_valid, decoded.pos_valid);
+  TEST_ASSERT_EQUAL_UINT8(1, decoded.pos_valid);
   TEST_ASSERT_EQUAL_INT32(fields.lat_e7, decoded.lat_e7);
   TEST_ASSERT_EQUAL_INT32(fields.lon_e7, decoded.lon_e7);
-  TEST_ASSERT_EQUAL_UINT16(fields.pos_age_s, decoded.pos_age_s);
   TEST_ASSERT_EQUAL_UINT16(1, decoded.seq);
 
   TEST_ASSERT_TRUE(logic.build_tx(20, fields, buffer, sizeof(buffer), &out_len));
-  naviga::protocol::decode_geo_beacon(naviga::protocol::ConstByteSpan{buffer, out_len}, &decoded);
+  naviga::protocol::decode_beacon(naviga::protocol::ConstByteSpan{buffer, out_len}, &decoded);
   TEST_ASSERT_EQUAL_UINT16(2, decoded.seq);
 }
 
@@ -151,10 +151,10 @@ void test_rx_success_updates_node_table() {
   fields.pos_age_s = 5;
   fields.seq = 42;
 
-  uint8_t payload[24] = {};
-  const size_t written = naviga::protocol::encode_geo_beacon(fields,
-                                                             naviga::protocol::ByteSpan{payload, sizeof(payload)});
-  TEST_ASSERT_EQUAL_UINT32(24, written);
+  uint8_t payload[32] = {};
+  const size_t written = naviga::protocol::encode_core(fields,
+                                                       naviga::protocol::ByteSpan{payload, sizeof(payload)});
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kCorePayloadSize, written);
 
   TEST_ASSERT_TRUE(logic.on_rx(1000, payload, written, -55, table));
   TEST_ASSERT_EQUAL_UINT32(1, table.size());
@@ -170,8 +170,31 @@ void test_rx_success_updates_node_table() {
 void test_rx_invalid_payload_no_change() {
   BeaconLogic logic;
   NodeTable table;
-  const uint8_t bad_payload[3] = {0x01, 0x01, 0x00};
+  const uint8_t bad_payload[3] = {0x00, 0x01, 0x00};
   TEST_ASSERT_FALSE(logic.on_rx(100, bad_payload, sizeof(bad_payload), -10, table));
+  TEST_ASSERT_EQUAL_UINT32(0, table.size());
+}
+
+void test_rx_alive_updates_node_table_no_position() {
+  BeaconLogic logic;
+  NodeTable table;
+  table.set_expected_interval_s(10);
+
+  uint8_t payload[32] = {};
+  const size_t written = naviga::protocol::encode_alive(0x0102030405060708ULL, 99,
+                                                         naviga::protocol::ByteSpan{payload, sizeof(payload)});
+  TEST_ASSERT_EQUAL_UINT32(naviga::protocol::kAlivePayloadSize, written);
+
+  TEST_ASSERT_TRUE(logic.on_rx(1000, payload, written, -60, table));
+  TEST_ASSERT_EQUAL_UINT32(1, table.size());
+}
+
+void test_rx_wrong_length_rejected() {
+  BeaconLogic logic;
+  NodeTable table;
+  uint8_t payload[20] = {0x00};
+  TEST_ASSERT_FALSE(logic.on_rx(100, payload, 12, -10, table));
+  TEST_ASSERT_FALSE(logic.on_rx(100, payload, 18, -10, table));
   TEST_ASSERT_EQUAL_UINT32(0, table.size());
 }
 
@@ -182,6 +205,8 @@ int main(int argc, char** argv) {
   RUN_TEST(test_tx_min_interval_no_update_no_send);
   RUN_TEST(test_tx_payload_correctness);
   RUN_TEST(test_rx_success_updates_node_table);
+  RUN_TEST(test_rx_alive_updates_node_table_no_position);
+  RUN_TEST(test_rx_wrong_length_rejected);
   RUN_TEST(test_rx_invalid_payload_no_change);
   return UNITY_END();
 }

--- a/firmware/test/test_geo_beacon_codec/test_geo_beacon_codec.cpp
+++ b/firmware/test/test_geo_beacon_codec/test_geo_beacon_codec.cpp
@@ -1,3 +1,6 @@
+/**
+ * Unit tests for #282: Core 19B and Alive 11B codecs per canon.
+ */
 #include <unity.h>
 
 #include <cstdint>
@@ -9,122 +12,181 @@ using naviga::protocol::ByteSpan;
 using naviga::protocol::ConstByteSpan;
 using naviga::protocol::DecodeError;
 using naviga::protocol::GeoBeaconFields;
-using naviga::protocol::decode_geo_beacon;
-using naviga::protocol::encode_geo_beacon;
+using naviga::protocol::decode_alive;
+using naviga::protocol::decode_beacon;
+using naviga::protocol::decode_core;
+using naviga::protocol::encode_alive;
+using naviga::protocol::encode_core;
+using naviga::protocol::kAlivePayloadSize;
+using naviga::protocol::kCorePayloadSize;
 
-void test_round_trip() {
-  GeoBeaconFields in{};
-  in.node_id = 0x1122334455667788ULL;
-  in.pos_valid = 1;
-  in.lat_e7 = 123456789;
-  in.lon_e7 = -987654321;
-  in.pos_age_s = 321;
-  in.seq = 4567;
-
-  uint8_t buf[24] = {};
-  size_t written = encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)});
-  TEST_ASSERT_EQUAL_UINT32(24, written);
-
-  GeoBeaconFields out{};
-  DecodeError err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::Ok, err);
-  TEST_ASSERT_EQUAL_UINT64(in.node_id, out.node_id);
-  TEST_ASSERT_EQUAL_UINT8(in.pos_valid, out.pos_valid);
-  TEST_ASSERT_EQUAL_INT32(in.lat_e7, out.lat_e7);
-  TEST_ASSERT_EQUAL_INT32(in.lon_e7, out.lon_e7);
-  TEST_ASSERT_EQUAL_UINT16(in.pos_age_s, out.pos_age_s);
-  TEST_ASSERT_EQUAL_UINT16(in.seq, out.seq);
-}
-
-void test_known_vector_decode() {
-  const uint8_t buf[24] = {
-      0x01, 0x01, 0x00, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
-      0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
-      0x03, 0x02};
-
-  GeoBeaconFields out{};
-  DecodeError err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::Ok, err);
-  TEST_ASSERT_EQUAL_UINT64(0x1122334455667788ULL, out.node_id);
-  TEST_ASSERT_EQUAL_UINT8(1, out.pos_valid);
-  TEST_ASSERT_EQUAL_INT32(0, out.lat_e7);
-  TEST_ASSERT_EQUAL_INT32(0, out.lon_e7);
-  TEST_ASSERT_EQUAL_UINT16(16, out.pos_age_s);
-  TEST_ASSERT_EQUAL_UINT16(0x0203, out.seq);
-}
-
-void test_encode_short_buffer() {
-  GeoBeaconFields in{};
-  uint8_t buf[23] = {};
-  size_t written = encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)});
-  TEST_ASSERT_EQUAL_UINT32(0, written);
-}
-
-void test_decode_short_buffer() {
-  uint8_t buf[23] = {};
-  GeoBeaconFields out{};
-  DecodeError err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::ShortBuffer, err);
-}
-
-void test_bad_msg_type_and_bad_version() {
+void test_core_encode_size_exactly_19() {
   GeoBeaconFields in{};
   in.node_id = 1;
-  in.pos_valid = 0;
+  in.pos_valid = 1;
   in.lat_e7 = 0;
   in.lon_e7 = 0;
-  in.pos_age_s = 0;
-  in.seq = 0;
+  in.seq = 1;
 
-  uint8_t buf[24] = {};
-  TEST_ASSERT_EQUAL_UINT32(24, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-
-  buf[0] = 0x02;
-  GeoBeaconFields out{};
-  DecodeError err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::BadMsgType, err);
-
-  buf[0] = 0x01;
-  buf[1] = 0x02;
-  err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::BadVersion, err);
+  uint8_t buf[32] = {};
+  size_t written = encode_core(in, ByteSpan{buf, sizeof(buf)});
+  TEST_ASSERT_EQUAL_UINT32(kCorePayloadSize, written);
+  TEST_ASSERT_EQUAL_UINT32(19, written);
 }
 
-void test_lat_lon_boundaries() {
-  GeoBeaconFields in{};
-  in.node_id = 42;
-  in.pos_valid = 1;
-  in.lat_e7 = 900000000;
-  in.lon_e7 = 1800000000;
-  in.pos_age_s = 0;
-  in.seq = 0;
+void test_alive_encode_size_exactly_11() {
+  uint8_t buf[32] = {};
+  size_t written = encode_alive(0x1122334455667788ULL, 42, ByteSpan{buf, sizeof(buf)});
+  TEST_ASSERT_EQUAL_UINT32(kAlivePayloadSize, written);
+  TEST_ASSERT_EQUAL_UINT32(11, written);
+}
 
-  uint8_t buf[24] = {};
-  TEST_ASSERT_EQUAL_UINT32(24, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
+void test_core_roundtrip() {
+  GeoBeaconFields in{};
+  in.node_id = 0x0123456789ABCDEFULL;
+  in.pos_valid = 1;
+  in.lat_e7 = 557558000;
+  in.lon_e7 = 376173000;
+  in.seq = 0x1234;
+
+  uint8_t buf[32] = {};
+  size_t written = encode_core(in, ByteSpan{buf, sizeof(buf)});
+  TEST_ASSERT_EQUAL_UINT32(19, written);
 
   GeoBeaconFields out{};
-  DecodeError err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
+  DecodeError err = decode_core(ConstByteSpan{buf, written}, &out);
   TEST_ASSERT_EQUAL(DecodeError::Ok, err);
+  TEST_ASSERT_EQUAL_UINT64(in.node_id, out.node_id);
+  TEST_ASSERT_EQUAL_UINT16(in.seq, out.seq);
+  TEST_ASSERT_EQUAL_INT32(in.lat_e7, out.lat_e7);
+  TEST_ASSERT_EQUAL_INT32(in.lon_e7, out.lon_e7);
+  TEST_ASSERT_EQUAL_UINT8(1, out.pos_valid);
+}
 
+void test_alive_roundtrip() {
+  const uint64_t node_id = 0xEFCDAB8967452301ULL;
+  const uint16_t seq = 2;
+
+  uint8_t buf[32] = {};
+  size_t written = encode_alive(node_id, seq, ByteSpan{buf, sizeof(buf)});
+  TEST_ASSERT_EQUAL_UINT32(11, written);
+
+  GeoBeaconFields out{};
+  DecodeError err = decode_alive(ConstByteSpan{buf, written}, &out);
+  TEST_ASSERT_EQUAL(DecodeError::Ok, err);
+  TEST_ASSERT_EQUAL_UINT64(node_id, out.node_id);
+  TEST_ASSERT_EQUAL_UINT16(seq, out.seq);
+  TEST_ASSERT_EQUAL_UINT8(0, out.pos_valid);
+  TEST_ASSERT_EQUAL_INT32(0, out.lat_e7);
+  TEST_ASSERT_EQUAL_INT32(0, out.lon_e7);
+}
+
+void test_decode_beacon_dispatch_by_length() {
+  GeoBeaconFields core_in{};
+  core_in.node_id = 1;
+  core_in.pos_valid = 1;
+  core_in.lat_e7 = 100;
+  core_in.lon_e7 = 200;
+  core_in.seq = 1;
+
+  uint8_t core_buf[32] = {};
+  size_t core_len = encode_core(core_in, ByteSpan{core_buf, sizeof(core_buf)});
+  GeoBeaconFields decoded{};
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_beacon(ConstByteSpan{core_buf, core_len}, &decoded));
+  TEST_ASSERT_EQUAL_UINT8(1, decoded.pos_valid);
+  TEST_ASSERT_EQUAL_INT32(100, decoded.lat_e7);
+
+  uint8_t alive_buf[32] = {};
+  size_t alive_len = encode_alive(2, 3, ByteSpan{alive_buf, sizeof(alive_buf)});
+  decoded = GeoBeaconFields{};
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_beacon(ConstByteSpan{alive_buf, alive_len}, &decoded));
+  TEST_ASSERT_EQUAL_UINT8(0, decoded.pos_valid);
+  TEST_ASSERT_EQUAL_UINT64(2, decoded.node_id);
+  TEST_ASSERT_EQUAL_UINT16(3, decoded.seq);
+}
+
+void test_wrong_length_rejected() {
+  uint8_t buf[20] = {0x00};
+  GeoBeaconFields out{};
+  TEST_ASSERT_EQUAL(DecodeError::BadMsgType, decode_beacon(ConstByteSpan{buf, 12}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::BadMsgType, decode_beacon(ConstByteSpan{buf, 18}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::BadMsgType, decode_beacon(ConstByteSpan{buf, 10}, &out));
+}
+
+void test_core_wrong_codec_fails() {
+  GeoBeaconFields in{};
+  in.node_id = 1;
+  in.pos_valid = 1;
+  in.lat_e7 = 0;
+  in.lon_e7 = 0;
+  in.seq = 0;
+
+  uint8_t buf[32] = {};
+  encode_core(in, ByteSpan{buf, sizeof(buf)});
+
+  GeoBeaconFields out{};
+  TEST_ASSERT_EQUAL(DecodeError::ShortBuffer, decode_alive(ConstByteSpan{buf, 19}, &out));
+}
+
+void test_alive_wrong_codec_fails() {
+  uint8_t buf[32] = {};
+  encode_alive(1, 0, ByteSpan{buf, sizeof(buf)});
+
+  GeoBeaconFields out{};
+  TEST_ASSERT_EQUAL(DecodeError::ShortBuffer, decode_core(ConstByteSpan{buf, 11}, &out));
+}
+
+void test_bad_version_rejected() {
+  uint8_t buf[32] = {};
+  encode_core(GeoBeaconFields{0, 1, 0, 0, 0, 0}, ByteSpan{buf, sizeof(buf)});
+  buf[0] = 0x01;
+
+  GeoBeaconFields out{};
+  TEST_ASSERT_EQUAL(DecodeError::BadVersion, decode_core(ConstByteSpan{buf, 19}, &out));
+}
+
+void test_core_lat_lon_invalid_range() {
+  GeoBeaconFields in{};
+  in.node_id = 1;
+  in.pos_valid = 1;
   in.lat_e7 = 900000001;
-  TEST_ASSERT_EQUAL_UINT32(24, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-  err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::InvalidRange, err);
+  in.lon_e7 = 0;
+  in.seq = 0;
 
-  in.lat_e7 = 900000000;
-  in.lon_e7 = 1800000001;
-  TEST_ASSERT_EQUAL_UINT32(24, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-  err = decode_geo_beacon(ConstByteSpan{buf, sizeof(buf)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::InvalidRange, err);
+  uint8_t buf[32] = {};
+  size_t written = encode_core(in, ByteSpan{buf, sizeof(buf)});
+  GeoBeaconFields out{};
+  TEST_ASSERT_EQUAL(DecodeError::InvalidRange, decode_core(ConstByteSpan{buf, written}, &out));
+}
+
+void test_core_known_vector() {
+  const uint8_t expected[19] = {
+      0x00, 0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+      0x01, 0x00,
+      0xF0, 0xA8, 0x3B, 0x21,
+      0xC8, 0xF1, 0x6B, 0x16
+  };
+  GeoBeaconFields out{};
+  DecodeError err = decode_core(ConstByteSpan{expected, sizeof(expected)}, &out);
+  TEST_ASSERT_EQUAL(DecodeError::Ok, err);
+  TEST_ASSERT_EQUAL_UINT64(0x0123456789ABCDEFULL, out.node_id);
+  TEST_ASSERT_EQUAL_UINT16(1, out.seq);
+  TEST_ASSERT_EQUAL_INT32(557558000, out.lat_e7);
+  TEST_ASSERT_EQUAL_INT32(376173000, out.lon_e7);
 }
 
 int main(int argc, char** argv) {
   UNITY_BEGIN();
-  RUN_TEST(test_round_trip);
-  RUN_TEST(test_known_vector_decode);
-  RUN_TEST(test_encode_short_buffer);
-  RUN_TEST(test_decode_short_buffer);
-  RUN_TEST(test_bad_msg_type_and_bad_version);
-  RUN_TEST(test_lat_lon_boundaries);
+  RUN_TEST(test_core_encode_size_exactly_19);
+  RUN_TEST(test_alive_encode_size_exactly_11);
+  RUN_TEST(test_core_roundtrip);
+  RUN_TEST(test_alive_roundtrip);
+  RUN_TEST(test_decode_beacon_dispatch_by_length);
+  RUN_TEST(test_wrong_length_rejected);
+  RUN_TEST(test_core_wrong_codec_fails);
+  RUN_TEST(test_alive_wrong_codec_fails);
+  RUN_TEST(test_bad_version_rejected);
+  RUN_TEST(test_core_lat_lon_invalid_range);
+  RUN_TEST(test_core_known_vector);
   return UNITY_END();
 }


### PR DESCRIPTION
Refs #282, #277, #224.

## Summary

- **Core payload:** 19 B (beacon_payload_encoding_v0): `payloadVersion(1) | nodeId(8) | seq16(2) | positionLat(4) | positionLon(4)`. Little-endian, version `0x00`.
- **Alive payload:** 11 B (alive_packet_encoding_v0): `payloadVersion(1) | nodeId(8) | seq16(2)`.
- **Codecs:** `encode_core` / `encode_alive`; `decode_core` / `decode_alive`; `decode_beacon(in)` dispatches by length (19 → Core, 11 → Alive). Strict size checks; wrong length or wrong codec returns error.
- **BeaconLogic:** `build_tx` uses `encode_core` for CORE and `encode_alive` for ALIVE; `on_rx` uses `decode_beacon` and rejects invalid payloads.
- **Tests:** `test_geo_beacon_codec` (exact 19/11 sizes, roundtrip, dispatch, wrong-codec reject, bad version, invalid range), `test_beacon_logic` (TX/RX sizes, Alive RX, wrong-length reject), `test_ootb_e2e_native`.

## msg_type framing (pending)

**Current implementation uses length-based decode** (19 bytes → Core, 11 bytes → Alive). Explicit msg_type framing is **pending clarification**; this PR will be adjusted once the framing decision is made. **#282 is not closed** until that is resolved.

## Test commands

```bash
pio run -e devkit_e220_oled_gnss
pio test -e test_native_nodetable -f test_geo_beacon_codec -f test_beacon_logic -f test_ootb_e2e_native
```

## Non-goals (unchanged)

- No Tail-1/Tail-2 (#283/#284).
- No TX degrade policy change (#285).
- No mesh/JOIN/CAD/LBT. No legacy BLE.
- No further payload layout changes beyond Core 19B / Alive 11B.

## Files

- `firmware/protocol/geo_beacon_codec.h` — kCorePayloadSize (19), kAlivePayloadSize (11), encode_core/alive, decode_core/alive/beacon
- `firmware/protocol/geo_beacon_codec.cpp` — implementations
- `firmware/src/domain/beacon_logic.cpp` — build_tx (encode_core vs encode_alive), on_rx (decode_beacon)
- `firmware/test/test_geo_beacon_codec/`, `firmware/test/test_beacon_logic/` — unit tests
