### PR TITLE
fw: rename RadioSmokeStats.last_seq → tx_event_seq (PR-B)

### DIFF
--- a/firmware/src/app/m1_runtime.cpp
+++ b/firmware/src/app/m1_runtime.cpp
@@ -206,10 +206,11 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
     }
   }
 
-  const uint32_t next_seq = stats_.last_seq + 1;
+  // tx_event_seq is an instrumentation TX event counter (uint32); not the on-air seq16 (uint16) from BeaconCore/Alive.
+  const uint32_t next_seq = stats_.tx_event_seq + 1;
   const bool ok = radio_->send(pending_payload_, pending_len_);
   send_policy_.on_send_result(ok, now_ms);
-  stats_.last_seq = next_seq;
+  stats_.tx_event_seq = next_seq;
   if (ok) {
     stats_.tx_count++;
     stats_.last_tx_ms = now_ms;
@@ -218,11 +219,11 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
       if (is_tail_type(last_tx_type_)) {
         std::snprintf(line, sizeof(line), "pkt tx t_ms=%lu type=%s seq=%u core_seq=%u",
                       static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
-                      static_cast<unsigned>(stats_.last_seq), static_cast<unsigned>(last_tx_core_seq_));
+                      static_cast<unsigned>(stats_.tx_event_seq), static_cast<unsigned>(last_tx_core_seq_));
       } else {
         std::snprintf(line, sizeof(line), "pkt tx t_ms=%lu type=%s seq=%u",
                       static_cast<unsigned long>(now_ms), packet_log_type_str(last_tx_type_),
-                      static_cast<unsigned>(stats_.last_seq));
+                      static_cast<unsigned>(stats_.tx_event_seq));
       }
       instrumentation_log_fn_(line, instrumentation_ctx_);
     }

--- a/firmware/src/services/radio_smoke_service.cpp
+++ b/firmware/src/services/radio_smoke_service.cpp
@@ -73,9 +73,9 @@ RadioRole RadioSmokeService::role() const {
 }
 
 void RadioSmokeService::send_ping(uint32_t now_ms) {
-  RadioMsg msg{static_cast<uint8_t>(RadioMsgType::Ping), stats_.last_seq + 1};
+  RadioMsg msg{static_cast<uint8_t>(RadioMsgType::Ping), stats_.tx_event_seq + 1};
   if (radio_->send(reinterpret_cast<const uint8_t*>(&msg), sizeof(msg))) {
-    stats_.last_seq = msg.seq;
+    stats_.tx_event_seq = msg.seq;
     stats_.tx_count++;
     stats_.last_tx_ms = now_ms;
     log_radio_event(event_logger_, now_ms, domain::LogEventId::RADIO_TX_OK,
@@ -89,7 +89,7 @@ void RadioSmokeService::send_ping(uint32_t now_ms) {
 void RadioSmokeService::send_pong(uint32_t seq, uint32_t now_ms) {
   RadioMsg msg{static_cast<uint8_t>(RadioMsgType::Pong), seq};
   if (radio_->send(reinterpret_cast<const uint8_t*>(&msg), sizeof(msg))) {
-    stats_.last_seq = msg.seq;
+    stats_.tx_event_seq = msg.seq;
     stats_.tx_count++;
     stats_.last_tx_ms = now_ms;
     log_radio_event(event_logger_, now_ms, domain::LogEventId::RADIO_TX_OK,
@@ -129,7 +129,7 @@ void RadioSmokeService::handle_rx(uint32_t now_ms) {
     stats_.last_rx_was_pong = true;
     stats_.rx_count++;
     stats_.last_rx_ms = now_ms;
-    stats_.last_seq = msg.seq;
+    stats_.tx_event_seq = msg.seq;
     log_radio_event(event_logger_, now_ms, domain::LogEventId::RADIO_RX_OK,
                     domain::LogLevel::kInfo, msg.type);
     if (stats_.rssi_available) {

--- a/firmware/src/services/radio_smoke_service.h
+++ b/firmware/src/services/radio_smoke_service.h
@@ -15,7 +15,8 @@ enum class RadioRole : uint8_t {
 struct RadioSmokeStats {
   uint32_t tx_count = 0;
   uint32_t rx_count = 0;
-  uint32_t last_seq = 0;
+  /** Instrumentation TX event counter (uint32). Not the on-air seq16 (uint16) from BeaconCore/Alive. */
+  uint32_t tx_event_seq = 0;
   uint32_t last_tx_ms = 0;
   uint32_t last_rx_ms = 0;
   int8_t last_rssi_dbm = 0;


### PR DESCRIPTION
## Summary

Follow-up PR-B from Issue #294 (seq16 productization plan).

`RadioSmokeStats.last_seq` was a `uint32` instrumentation TX event counter used by `RadioSmokeService` (ping/pong smoke test) and `M1Runtime` logging. The name clashed visually with the on-air `seq16` (`uint16`) from BeaconCore and Alive packets, making the code harder to read at a glance.

**Rename:** `last_seq` → `tx_event_seq` in `RadioSmokeStats`.  
**Add:** clarifying comment in `m1_runtime.cpp` near the logging path.

## Files changed

| File | Change |
|------|--------|
| `firmware/src/services/radio_smoke_service.h` | Rename field + add doc comment |
| `firmware/src/services/radio_smoke_service.cpp` | Update 3 references |
| `firmware/src/app/m1_runtime.cpp` | Update 4 references + add clarifying comment |

## Quality gates

- [x] No behavior changes
- [x] No protocol / on-air changes
- [x] No changes to seq16 logic, wrap handling, BeaconLogic, or NodeTable
- [x] `grep -rn "stats_\.last_seq" firmware/src/` → zero results
- [x] All 49 unit tests pass (`pio test -e test_native`)
- [x] One commit, firmware-only diff

## References

- Issue #294 — Seq16 productization plan (follow-up PR-B)
- PR #293 — docs canonization (seq16 audit, reboot behaviour, wrap rule)

Made with [Cursor](https://cursor.com)