### PR TITLE
docs(wip/research): NodeID and geo encoding audit (S02)

### DIFF
--- a/docs/product/wip/research/geo_encoding_audit_s02.md
+++ b/docs/product/wip/research/geo_encoding_audit_s02.md
@@ -1,0 +1,247 @@
+# Geo Encoding Audit — S02
+
+**Status:** Research / WIP (not canon).
+**Iteration:** S02__2026-03__docs_promotion_and_arch_audit
+**Work Area:** Docs (audit)
+**Date:** 2026-02-26
+**Non-goal:** No code changes, no semantic changes, no mesh/JOIN changes.
+**OOTB policy:** OOTB docs referenced only as examples/indicators; canon = contracts/policy/spec under `docs/product/areas/`.
+
+---
+
+## 1. As-Is Summary
+
+### 1.1 Current on-air geo encoding (implemented)
+
+The only implemented on-air geo encoding is in `firmware/protocol/geo_beacon_codec.cpp`. It uses **absolute WGS84 coordinates encoded as int32 × 1e7**, with no delta or sector compression.
+
+**BeaconCore payload (19 bytes, fixed):**
+
+| Byte offset | Field | Type | Size | Encoding |
+|-------------|-------|------|------|----------|
+| 0 | `payloadVersion` | uint8 | 1 | `0x00` = v0 |
+| 1–8 | `nodeId` | uint64 LE | 8 | Device ID |
+| 9–10 | `seq` | uint16 LE | 2 | Freshness counter |
+| 11–14 | `lat_e7` | int32 LE | 4 | Latitude × 1e7 (WGS84); range −900 000 000 .. +900 000 000 |
+| 15–18 | `lon_e7` | int32 LE | 4 | Longitude × 1e7 (WGS84); range −1 800 000 000 .. +1 800 000 000 |
+
+**Total: 19 bytes.** No `pos_valid` flag in the payload itself — the packet type (Core vs Alive) encodes validity implicitly (Core = valid fix, Alive = no fix).
+
+> **Note on codec vs canon mismatch:** The current codec (`geo_beacon_codec.h/cpp`) uses a different layout than the canon contract (`beacon_payload_encoding_v0.md`). See §3 Gaps.
+
+**Alive payload (11 bytes, fixed):**
+
+| Byte offset | Field | Type | Size |
+|-------------|-------|------|------|
+| 0 | `payloadVersion` | uint8 | 1 |
+| 1–8 | `nodeId` | uint64 LE | 8 |
+| 9–10 | `seq` | uint16 LE | 2 |
+
+No position fields. Alive = no-fix liveness signal only.
+
+---
+
+### 1.2 Canon contract geo encoding (`beacon_payload_encoding_v0.md`)
+
+The canon contract defines the same absolute WGS84 × 1e7 encoding but with a slightly different field order:
+
+**BeaconCore (canon, 19 bytes):**
+
+| Byte offset | Field | Type | Size | Encoding |
+|-------------|-------|------|------|----------|
+| 0 | `payloadVersion` | uint8 | 1 | `0x00` |
+| 1–8 | `nodeId` | uint64 LE | 8 | |
+| 9–10 | `seq16` | uint16 LE | 2 | |
+| 11–14 | `positionLat` | int32 LE | 4 | Latitude × 1e7 (WGS84) |
+| 15–18 | `positionLon` | int32 LE | 4 | Longitude × 1e7 (WGS84) |
+
+**Encoding semantics (canon):**
+- `positionLat` = latitude in degrees × 10^7, signed int32. Range: −90° to +90° → −900 000 000 to +900 000 000.
+- `positionLon` = longitude in degrees × 10^7, signed int32. Range: −180° to +180° → −1 800 000 000 to +1 800 000 000.
+- Precision: 1 unit = 0.0000001° ≈ 1.1 cm at equator. Sufficient for all V1-A use cases.
+- Little-endian byte order for all multi-byte fields.
+- BeaconCore MUST NOT be transmitted without a valid GNSS fix.
+
+**Source:** `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md §4.1`
+
+---
+
+### 1.3 Firmware codec geo encoding (`geo_beacon_codec.cpp`)
+
+The firmware codec (`firmware/protocol/geo_beacon_codec.cpp`) encodes the same fields but with a **different byte layout**:
+
+**Codec layout (24 bytes):**
+
+| Byte offset | Field | Type | Size | Notes |
+|-------------|-------|------|------|-------|
+| 0 | `kGeoBeaconMsgType` = `0x01` | uint8 | 1 | Written as byte 0 |
+| 1 | `kGeoBeaconVersion` = `1` | uint8 | 1 | Written as byte 1 |
+| 2 | reserved / `0x00` | uint8 | 1 | Padding |
+| 3–10 | `node_id` | uint64 LE | 8 | |
+| 11 | `pos_valid` | uint8 | 1 | 0 = no fix, non-zero = valid |
+| 12–15 | `lat_e7` | int32 LE | 4 | Latitude × 1e7 |
+| 16–19 | `lon_e7` | int32 LE | 4 | Longitude × 1e7 |
+| 20–21 | `pos_age_s` | uint16 LE | 2 | Position age in seconds |
+| 22–23 | `seq` | uint16 LE | 2 | Sequence counter |
+
+**Total: 24 bytes (`kGeoBeaconSize = 24`).** Constant `kGeoBeaconVersion = 1` (not `0x00`).
+
+**Source:** `firmware/protocol/geo_beacon_codec.h` lines 9–16, 36–38; `firmware/protocol/geo_beacon_codec.cpp` lines 73–89.
+
+---
+
+### 1.4 NodeTable domain geo fields
+
+The domain `NodeEntry` struct stores geo fields as received from the codec:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `pos_valid` | bool | Whether lat/lon are valid |
+| `lat_e7` | int32_t | Latitude × 1e7 |
+| `lon_e7` | int32_t | Longitude × 1e7 |
+| `pos_age_s` | uint16_t | Age of position in seconds |
+
+**Source:** `firmware/src/domain/node_table.h` lines 14–18.
+
+These are populated by `beacon_logic.cpp:on_rx()` → `table.upsert_remote(node_id, pos_valid, lat_e7, lon_e7, pos_age_s, rssi_dbm, seq, now_ms)`.
+
+---
+
+### 1.5 BLE export geo fields
+
+The 26-byte BLE NodeTableSnapshot record exports geo fields at fixed offsets:
+
+| Offset | Field | Type | Size |
+|--------|-------|------|------|
+| 13–16 | `lat_e7` | uint32 LE (cast from int32) | 4 |
+| 17–20 | `lon_e7` | uint32 LE (cast from int32) | 4 |
+| 21–22 | `pos_age_s` | uint16 LE | 2 |
+
+**Source:** `firmware/src/domain/node_table.cpp` `get_page()` lines 272–274.
+
+---
+
+### 1.6 Mesh concept geo encoding
+
+The mesh concept (`naviga_mesh_protocol_concept_v1_4.md §5`) references `origin_pos` as a field in the geo packet, described as "position of origin in compressed format." No byte layout is defined — the concept explicitly defers encoding to a future spec.
+
+Key quote (§5): `origin_pos — позиция origin в сжатом формате.`
+
+The concept also mentions `bridge_hop_pos` (position of the current relay hop) as a separate field. Neither field has a defined byte layout in any current doc.
+
+**Estimated geo packet size (concept):** ~40 bytes total including `origin_pos`, `covered_mask` (8 bytes), `origin_id`, `bridge_hop_id`, `bridge_hop_pos`, `seq`, `hop_count`, `TTL`. Source: `naviga_mesh_protocol_concept_v1_4.md §3.4` (line 197, 371).
+
+---
+
+## 2. Where Defined (file + section)
+
+| Artefact | File | Section / line |
+|----------|------|---------------|
+| Canon geo encoding (lat/lon × 1e7, LE, int32) | `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | §4.1 BeaconCore table |
+| Canon range constraints (lat/lon valid range) | `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | §4.1 row "positionLat" / "positionLon" |
+| Canon: Core only with valid fix | `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | §3.1 "Position-bearing vs Alive-bearing" |
+| Firmware codec struct (`GeoBeaconFields`) | `firmware/protocol/geo_beacon_codec.h` | Lines 9–16 |
+| Firmware codec constants (`kGeoBeaconSize=24`, `kGeoBeaconVersion=1`) | `firmware/protocol/geo_beacon_codec.h` | Lines 36–38 |
+| Firmware codec encode/decode | `firmware/protocol/geo_beacon_codec.cpp` | Lines 73–119 |
+| Range validation in codec | `firmware/protocol/geo_beacon_codec.cpp` | Lines 8–11 (`kLatMin/Max`, `kLonMin/Max`); lines 111–116 |
+| Domain `NodeEntry` geo fields | `firmware/src/domain/node_table.h` | Lines 14–18 |
+| Domain upsert (pos_valid gating) | `firmware/src/domain/node_table.cpp` | Lines 166–169, 205–208 |
+| BLE record geo offsets | `firmware/src/domain/node_table.cpp` | Lines 272–274 (`get_page`) |
+| Mobile geo fields (`latE7`, `lonE7`, `posAgeS`) | `app/lib/features/connect/connect_controller.dart` | `NodeRecordV1` model; `BleNodeTableParser.parsePage` |
+| Mesh concept `origin_pos` (compressed, TBD) | `docs/product/naviga_mesh_protocol_concept_v1_4.md` | §5 (line 583); §3.4 (size estimate ~40B) |
+| OOTB-era geo field spec (TBD encoding) | `docs/protocols/ootb_radio_v0.md` | §3.2 GEO_BEACON "position (lat/lon fixed-point TBD)" |
+| `pos_age_s` definition | `docs/firmware/ootb_node_table_v0.md` | §3 row "pos_age_s" (OOTB-era; non-canon) |
+
+---
+
+## 3. Gaps & Risks
+
+| # | Gap / Risk | Severity | Details |
+|---|-----------|----------|---------|
+| G1 | **Codec layout diverges from canon contract** | High | Canon (`beacon_payload_encoding_v0.md §4.1`) defines 19-byte BeaconCore with layout: `payloadVersion(1) \| nodeId(8) \| seq16(2) \| positionLat(4) \| positionLon(4)`. Firmware codec (`geo_beacon_codec.cpp`) uses 24-byte layout: `msg_type(1) \| version(1) \| reserved(1) \| nodeId(8) \| pos_valid(1) \| lat_e7(4) \| lon_e7(4) \| pos_age_s(2) \| seq(2)`. These are **incompatible on-air**. The codec has a `pos_valid` byte and `pos_age_s` field not present in the canon payload; the canon has `payloadVersion=0x00` where the codec has `msg_type=0x01`. |
+| G2 | **`kGeoBeaconVersion = 1` vs canon `payloadVersion = 0x00`** | High | Codec uses version byte `1`; canon contract defines `payloadVersion = 0x00` for v0. These are different versioning layers (frame header `ver` vs payload `payloadVersion`) but the naming and values conflict. See also `_working/protocol_research/2026-02-25_on_air_framing_ootb_report.md §2.1` for full analysis. |
+| G3 | **`pos_valid` byte in codec not in canon payload** | Medium | The codec encodes `pos_valid` as byte 11 of the 24-byte packet. The canon contract does NOT include a `pos_valid` field in the BeaconCore payload — instead, the Core/Alive packet type distinction carries the validity semantics. This is a structural difference: codec uses a single packet type with a validity flag; canon uses two packet types (Core = valid, Alive = no-fix). |
+| G4 | **`pos_age_s` in codec not in canon BeaconCore** | Medium | The codec encodes `pos_age_s` (uint16, bytes 20–21). The canon BeaconCore does not include `pos_age_s` — it is a Tail-1/Tail-2 field in the canon model. The OOTB-era spec (`ootb_radio_v0.md §3.2`) lists `pos_age_s` as a "required core freshness indicator" (TBD). This field exists in the codec and domain but has no canon placement in BeaconCore. |
+| G5 | **Mesh `origin_pos` encoding is undefined** | Medium | The mesh concept says `origin_pos` is in "compressed format" but provides no byte layout. No doc defines delta coding, sector encoding, or any compact geo scheme for mesh packets. The ~40-byte mesh packet estimate assumes some compression but the method is TBD. |
+| G6 | **No canon doc for `pos_age_s` semantics** | Low | `pos_age_s` is used throughout firmware and BLE export but its canon definition is only in the OOTB-era `ootb_node_table_v0.md §3` (non-canon). The canon `beacon_payload_encoding_v0.md` does not define `pos_age_s` for BeaconCore (it appears only as an optional Tail field). |
+| G7 | **`pos_valid` gating in domain is correct but undocumented** | Low | `node_table.cpp` correctly gates lat/lon storage on `pos_valid` (lines 166–169, 205–208): if `!pos_valid`, lat/lon stored as 0. This is correct behaviour but no canon policy doc explicitly states "receiver MUST zero lat/lon when pos_valid=false." |
+| G8 | **No delta / compact encoding defined or implemented** | Low (V1-A) | The mesh concept requires compact geo encoding (~40B total packet). No delta coding, sector encoding, or fixed-point compression scheme is defined anywhere in docs or code. For V1-A OOTB (no mesh), this is not blocking; for mesh, it will need a spec. |
+
+---
+
+## 4. Candidate Options
+
+### Option A: Align canon contract with firmware codec (docs-only)
+
+Update `beacon_payload_encoding_v0.md` to match the actual 24-byte codec layout, adding `pos_valid` and `pos_age_s` to BeaconCore, and clarifying the frame header bytes (`msg_type`, `ver`, `reserved`).
+
+**Pros:** Closes G1, G2, G3, G4 without code changes.
+**Cons:** Changes the canon contract (requires review); the 24-byte layout is larger than the canon's 19-byte budget for LongDist profile (budget = 24B, so it just fits); adds `pos_valid` byte which the canon model intentionally avoids (Core = valid by definition).
+
+### Option B: Align firmware codec with canon contract (code change)
+
+Update the codec to implement the 19-byte canon layout: remove `msg_type`, `ver`, `reserved`, `pos_valid` bytes; move `pos_age_s` out of BeaconCore (into Tail-1 or Tail-2); use `payloadVersion = 0x00`.
+
+**Pros:** Firmware matches canon; smaller packet (19B vs 24B); consistent with the Core/Alive type-based validity model.
+**Cons:** Breaking change (all devices must update simultaneously); requires implementing the OOTB 3-byte frame header separately (per `ootb_radio_v0.md §3.1`) to preserve `msg_type` dispatch.
+
+### Option C: Hybrid — add frame header, keep payload structure close to codec
+
+Implement the 3-byte OOTB frame header (`msg_type=0x01 | ver=0x01 | flags=0x00`) prepended to the current codec payload, but remove the redundant `pos_valid` byte from the payload and rely on packet type (Core vs Alive) for validity. BeaconCore payload becomes: `payloadVersion(1) | nodeId(8) | seq16(2) | lat_e7(4) | lon_e7(4) | pos_age_s(2)` = 21 bytes + 3-byte header = 24 bytes total.
+
+**Pros:** Aligns with OOTB frame spec; keeps `pos_age_s` in Core (useful for receivers); removes `pos_valid` redundancy; total size unchanged (24B).
+**Cons:** Still diverges from canon 19-byte BeaconCore; requires code + doc changes.
+
+### Option D: Status quo + document the divergence (docs-only, minimal)
+
+Add a note to `beacon_payload_encoding_v0.md` or a new WIP doc explicitly stating: "Current firmware implements a 24-byte variant; the 19-byte canon layout is the target for a future migration." No code changes.
+
+**Pros:** Zero risk; unblocks other work; honest about current state.
+**Cons:** Leaves the divergence unresolved; risk of new code being written against either layout.
+
+---
+
+## 5. Recommendation for Next PRs
+
+### PR 1 (docs-only, recommended immediately)
+
+**Scope:** Create a WIP doc `docs/product/wip/areas/nodetable/research/geo_encoding_delta_s02.md` (or similar) that:
+1. Documents the current 24-byte codec layout as "as-implemented" (non-canon).
+2. Documents the canon 19-byte BeaconCore layout as "target."
+3. Explicitly lists the 5 field-level differences (G1–G4).
+4. Recommends Option B or C as the resolution path, pending owner decision.
+5. Notes that `pos_age_s` needs a canon placement decision (BeaconCore vs Tail-1).
+
+**Files changed:** 1 new WIP doc. No code changes.
+
+### PR 2 (docs-only, follow-up)
+
+**Scope:** Update `beacon_payload_encoding_v0.md` to either:
+- (if Option B chosen) Confirm the 19-byte canon layout is the target and add a migration note.
+- (if Option C chosen) Update the layout table to reflect the hybrid 24-byte layout with frame header.
+
+**Files changed:** `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md`.
+
+### PR 3 (code, after PR 2 decision)
+
+**Scope:** Update `firmware/protocol/geo_beacon_codec.cpp` to implement the chosen layout. Coordinate with all device firmware updates (breaking change).
+
+---
+
+## 6. File Reference Index
+
+| File | Role | Key lines |
+|------|------|-----------|
+| `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | Canon: BeaconCore geo layout | §4.1 (19B layout table); §3.1 (Core only with valid fix) |
+| `docs/product/areas/nodetable/contract/alive_packet_encoding_v0.md` | Canon: Alive (no geo) | §3.1 (11B layout) |
+| `docs/product/areas/nodetable/policy/nodetable_fields_inventory_v0.md` | Canon: positionLat/Lon rows | Rows "positionLat", "positionLon", "posFlags", "sats" |
+| `docs/protocols/ootb_radio_v0.md` | OOTB-era frame spec | §3.2 GEO_BEACON v1 fields; "position (lat/lon fixed-point TBD)" |
+| `docs/firmware/ootb_node_table_v0.md` | OOTB-era: pos_age_s | §3 row "pos_age_s" |
+| `docs/product/naviga_mesh_protocol_concept_v1_4.md` | Concept: origin_pos (compressed, TBD) | §5 (line 583); §3.4 (size ~40B) |
+| `firmware/protocol/geo_beacon_codec.h` | Impl: GeoBeaconFields struct, constants | Lines 9–16 (struct); 36–38 (kGeoBeaconSize=24, kGeoBeaconMsgType=0x01, kGeoBeaconVersion=1) |
+| `firmware/protocol/geo_beacon_codec.cpp` | Impl: encode/decode | Lines 73–89 (encode); 91–119 (decode); 8–11 (range constants) |
+| `firmware/src/domain/node_table.h` | Domain: NodeEntry geo fields | Lines 14–18 |
+| `firmware/src/domain/node_table.cpp` | Domain: pos_valid gating, BLE export | Lines 166–169, 205–208 (upsert); 272–274 (get_page) |
+| `firmware/src/domain/beacon_logic.cpp` | Domain: on_rx geo flow | Lines 80–108 |
+| `firmware/src/app/m1_runtime.cpp` | Wiring: set_self_position | Lines 80–113 |
+| `_working/protocol_research/2026-02-25_on_air_framing_ootb_report.md` | Research: frame header vs payload version analysis | §2.1 (ootb_radio_v0 spec); §3.1 (codec constants); §6.1 (gap table) |

--- a/docs/product/wip/research/nodeid_audit_s02.md
+++ b/docs/product/wip/research/nodeid_audit_s02.md
@@ -1,0 +1,186 @@
+# NodeID Audit — S02
+
+**Status:** Research / WIP (not canon).
+**Iteration:** S02__2026-03__docs_promotion_and_arch_audit
+**Work Area:** Docs (audit)
+**Date:** 2026-02-26
+**Non-goal:** No code changes, no semantic changes, no mesh/JOIN changes.
+**OOTB policy:** OOTB docs referenced only as examples/indicators; canon = contracts/policy/spec under `docs/product/areas/`.
+
+---
+
+## 1. As-Is Summary
+
+### 1.1 Concept map
+
+| Concept | Name in docs | Name in code | Size | Where defined |
+|---------|-------------|-------------|------|---------------|
+| Primary node key | `nodeId` / `node_id` | `node_id` (uint64_t) | 8 bytes | `beacon_payload_encoding_v0.md §4.1`; `alive_packet_encoding_v0.md §3.1`; `firmware/src/domain/node_table.h` |
+| Display / short key | `ShortId` / `short_id` | `short_id` (uint16_t) | 2 bytes | `nodetable_fields_inventory_v0.md` row "ShortId"; `firmware/src/domain/node_table.h` |
+| Mesh session key | `short_id` (0..63) | — (not implemented) | 6 bits | `naviga_mesh_protocol_concept_v1_4.md §3.2` |
+| Hardware source | ESP32 eFuse MAC | `esp_efuse_mac_get_default` | 6 bytes raw | `firmware/src/platform/esp_device_id_provider.cpp` |
+| Wire encoding of nodeId | uint64 LE | `write_u64_le` | 8 bytes | `firmware/protocol/geo_beacon_codec.cpp`; `firmware/src/domain/node_table.cpp` |
+
+---
+
+### 1.2 NodeID formation chain (firmware)
+
+```
+esp_efuse_mac_get_default(base_mac[6])          // esp_device_id_provider.cpp:16
+  → DeviceId{bytes[6]}                           // naviga/platform/device_id.h
+  → full_id_from_mac(device_id.bytes)            // platform/device_id.cpp:68
+      id = 0x0000<mac[0]..mac[5]>               // big-endian packing into lower 6 bytes
+      → uint64_t (upper 2 bytes = 0x0000)
+  → domain::NodeTable::compute_short_id(full_id) // domain/node_table.cpp:62
+      → CRC16-CCITT over 8 bytes (LE of full_id)
+```
+
+**Wiring entry point:** `firmware/src/app/app_services.cpp` line 147–151.
+
+---
+
+### 1.3 Where nodeId appears as a key
+
+| Role | Location | Notes |
+|------|----------|-------|
+| NodeTable primary key (lookup) | `firmware/src/domain/node_table.cpp` `find_entry_index()` | `node_id == entry.node_id` |
+| NodeTable primary key (init) | `node_table.cpp` `init_self()`, `upsert_remote()` | Stored in `NodeEntry.node_id` |
+| On-air beacon (Core/Tail-1/Tail-2/Alive) | `firmware/protocol/geo_beacon_codec.cpp` | Bytes 1–8 of payload (after payloadVersion byte) in current codec; bytes 3–10 in OOTB-spec codec (after msg_type+ver+flags header — not yet implemented) |
+| BLE NodeTableSnapshot record | `firmware/src/domain/node_table.cpp` `get_page()` offset 0 | 8 bytes LE |
+| Mobile model | `app/lib/features/connect/connect_controller.dart` `NodeRecordV1.nodeId` | Parsed from BLE record |
+| Dedup / seq ordering key | `node_table.cpp` `upsert_remote()` seq16_order | Per-node seq16 counter keyed by node_id |
+| Mesh dedup key | `naviga_mesh_protocol_concept_v1_4.md §5` | `(origin_id, seq)` pair; `origin_id` = mesh `short_id` (0..63), not uint64 |
+
+---
+
+### 1.4 short_id derivation — two implementations
+
+| Location | Input | Algorithm | Output |
+|----------|-------|-----------|--------|
+| `firmware/src/domain/node_table.cpp` `compute_short_id()` line 62 | `uint64_t node_id` serialised as 8 bytes **LE** | CRC16-CCITT-FALSE (`init=0xFFFF`, `poly=0x1021`) | `uint16_t` |
+| `firmware/src/platform/device_id.cpp` `short_id_from_mac()` line 81 | `uint8_t mac[6]` (6 bytes, MAC order) | CRC16-CCITT-FALSE (`init=0xFFFF`, `poly=0x1021`) | `uint16_t` |
+
+**Gap:** These two functions operate on different inputs (8-byte LE of uint64 vs 6-byte MAC). Because `full_id_from_mac` packs MAC bytes big-endian into the lower 6 bytes of a uint64, and `compute_short_id` serialises that uint64 back as 8 bytes LE, the byte sequences fed to CRC differ:
+
+- `short_id_from_mac(mac[6])` → CRC16 over `[mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]]`
+- `compute_short_id(full_id_from_mac(mac))` → CRC16 over `[mac[5], mac[4], mac[3], mac[2], mac[1], mac[0], 0x00, 0x00]`
+
+These produce **different CRC16 values** for the same device. In practice `app_services.cpp` uses `compute_short_id(full_id)` (line 151), so the domain path is consistent; `short_id_from_mac` in `device_id.cpp` is a standalone utility that is not called from the main wiring path.
+
+---
+
+### 1.5 Mesh short_id (session key) vs NodeTable short_id (display key)
+
+| | NodeTable `short_id` | Mesh `short_id` |
+|--|---------------------|-----------------|
+| Range | uint16 (0..65535) | 0..63 (6 bits) |
+| Purpose | Display / UI label; collision detection | `covered_mask` bit index; `origin_id`; `bridge_hop_id` in mesh packet |
+| Assignment | Derived: CRC16 of node_id | Session-assigned (mechanism TBD per mesh concept) |
+| Canon source | `nodetable_fields_inventory_v0.md` row "ShortId"; `ootb_node_table_v0.md §1a` | `naviga_mesh_protocol_concept_v1_4.md §3.2` |
+| Implemented? | Yes | No (mesh not implemented) |
+
+These are **two distinct concepts sharing the same name** — a naming collision risk.
+
+---
+
+## 2. Where Defined (file + section)
+
+| Artefact | File | Section / line |
+|----------|------|---------------|
+| `nodeId` on-air layout (uint64 LE, bytes 1–8 of payload) | `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | §4.1 BeaconCore; §4.2 Tail-1; §4.3 Tail-2 |
+| `nodeId` in Alive packet | `docs/product/areas/nodetable/contract/alive_packet_encoding_v0.md` | §3.1 Minimum payload |
+| `nodeId` semantics (DeviceId, primary key) | `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | §4.1 row "nodeId" |
+| `ShortId` definition (derived, display only) | `docs/product/areas/nodetable/policy/nodetable_fields_inventory_v0.md` | Row "ShortId" |
+| `short_id` collision handling | `docs/firmware/ootb_node_table_v0.md` | §1a (OOTB-era, non-canon; still the most detailed collision spec) |
+| NodeTable primary key semantics | `docs/product/areas/nodetable/index.md` | §3 Contracts |
+| Hardware source (eFuse MAC) | `firmware/src/platform/esp_device_id_provider.cpp` | Line 16 (`esp_efuse_mac_get_default`) |
+| `IDeviceIdProvider` interface | `firmware/lib/NavigaCore/include/naviga/platform/device_id.h` | `struct DeviceId{bytes[6]}`; `struct IDeviceIdProvider` |
+| `full_id_from_mac` (MAC → uint64) | `firmware/src/platform/device_id.cpp` | Lines 68–79 |
+| `compute_short_id` (uint64 → CRC16) | `firmware/src/domain/node_table.cpp` | Lines 62–66 |
+| `short_id_from_mac` (MAC → CRC16, standalone) | `firmware/src/platform/device_id.cpp` | Lines 81–87 |
+| Mesh `short_id` (0..63, session key) | `docs/product/naviga_mesh_protocol_concept_v1_4.md` | §3.2 (short_id ∈ [0..63]); §5 (origin_id, bridge_hop_id) |
+| seq16 scope (single per-node counter) | `docs/product/areas/nodetable/index.md` | §2 V1-A invariants |
+| seq16 dedup / ordering | `firmware/src/domain/node_table.cpp` | Lines 17–23 (`seq16_order`) |
+
+---
+
+## 3. Gaps & Risks
+
+| # | Gap / Risk | Severity | Details |
+|---|-----------|----------|---------|
+| G1 | **Two `short_id` concepts share the same name** | Medium | NodeTable `short_id` (uint16, CRC16 display key) vs Mesh `short_id` (0..63, session bit-index). Mesh concept uses `short_id` as `origin_id` and in `covered_mask`; NodeTable uses it for UI only. When mesh is implemented, the naming collision will cause confusion. No canon doc disambiguates them. |
+| G2 | **`short_id_from_mac` and `compute_short_id` produce different values** | Low (currently) | `device_id.cpp:short_id_from_mac` takes 6 MAC bytes; `node_table.cpp:compute_short_id` takes 8-byte LE of uint64. The main wiring path (`app_services.cpp`) uses `compute_short_id`, so runtime is consistent. But `short_id_from_mac` exists as a public API and could be called by mistake, producing a different short_id for the same device. |
+| G3 | **No canon doc for `short_id` collision handling** | Low | `ootb_node_table_v0.md §1a` is the most detailed collision spec (reserved values 0x0000/0xFFFF, disambiguation display). This is an OOTB-era doc, not promoted to canon. `nodetable_fields_inventory_v0.md` row "ShortId" only says "may collide". |
+| G4 | **NodeID source (eFuse MAC) not documented in canon** | Low | Canon contracts say `nodeId = DeviceId (e.g. ESP32-S3 MCU ID)` but do not specify the exact hardware source. The eFuse MAC path is only in firmware code. No canon policy doc covers factory-reset behaviour, MAC type selection order (`ESP_MAC_BLE` → `ESP_MAC_BT` → `esp_efuse_mac_get_default`). |
+| G5 | **Mesh `short_id` assignment mechanism is TBD** | Medium | `naviga_mesh_protocol_concept_v1_4.md §3.2` says "Mechanism for assigning short_id is part of session management and is considered separately from the mesh protocol." No doc defines this mechanism. |
+| G6 | **Upper 2 bytes of nodeId are always 0x0000** | Low | `full_id_from_mac` packs 6 MAC bytes into the lower 6 bytes of uint64, leaving upper 2 bytes zero. This is not documented as a constraint in any canon doc. Future ID sources (e.g. non-MAC) could use the full 64 bits; the current assumption is implicit. |
+| G7 | **`long_id` term appears in OOTB-era docs but not in canon** | Low | `ootb_node_table_v0.md §1` uses "64-bit integer" without naming it `long_id`. Some older research notes use `long_id`. Canon contracts use `nodeId`. No explicit mapping doc. |
+
+---
+
+## 4. Candidate Options
+
+### Option A: Status quo + disambiguation doc (docs-only)
+
+Add a short canon policy doc (e.g. `docs/product/areas/identity/nodeid_policy_v0.md`) that:
+- Defines `nodeId` = uint64, source = eFuse MAC via `full_id_from_mac`, upper 2 bytes reserved = 0x0000.
+- Defines `ShortId` = CRC16-CCITT-FALSE over 8-byte LE of nodeId; display only; not a protocol key.
+- Explicitly names the two `short_id` concepts and disambiguates: "NodeTable ShortId" vs "Mesh SessionId (0..63)".
+- Documents collision handling (reserved values, display format).
+
+**Pros:** No code change; resolves G1, G3, G4, G7.
+**Cons:** Does not fix G2 (two functions producing different values).
+
+### Option B: Option A + deprecate `short_id_from_mac`
+
+Same as A, plus mark `firmware/src/platform/device_id.cpp:short_id_from_mac` as deprecated (comment or remove), since the canonical path is `compute_short_id(full_id_from_mac(mac))`.
+
+**Pros:** Closes G2; reduces confusion.
+**Cons:** Small code change (comment or removal); must verify no callers outside main path.
+
+### Option C: Rename mesh session key in concept doc
+
+In `naviga_mesh_protocol_concept_v1_4.md`, rename the 0..63 session identifier to `session_id` or `mesh_slot_id` to avoid collision with NodeTable `short_id`.
+
+**Pros:** Eliminates G1 at the concept level before mesh is implemented.
+**Cons:** Mesh concept is a concept doc (not canon); renaming now may diverge from future mesh spec.
+
+---
+
+## 5. Recommendation for Next PRs
+
+### PR 1 (docs-only, recommended immediately)
+
+**Scope:** Create `docs/product/areas/identity/nodeid_policy_v0.md` (or equivalent) covering:
+1. `nodeId` = uint64; source = eFuse MAC (`esp_efuse_mac_get_default`); packing = `full_id_from_mac` (big-endian MAC bytes into lower 6 bytes of uint64, upper 2 bytes = 0x0000).
+2. `ShortId` = CRC16-CCITT-FALSE over 8-byte LE of nodeId; display only; MUST NOT be used as protocol key.
+3. Disambiguation: "NodeTable ShortId (uint16)" vs "Mesh Session Slot (0..63, TBD)".
+4. Collision handling: reserved values (0x0000, 0xFFFF), display format, `short_id_collision` flag.
+5. Factory-reset policy: nodeId does not change on reset (per `ootb_node_table_v0.md §1`, promote to canon).
+
+**Files changed:** 1 new doc. No code changes.
+
+### PR 2 (optional, code-only, low priority)
+
+**Scope:** Deprecate or remove `short_id_from_mac` in `firmware/src/platform/device_id.cpp` (or add a comment explaining it produces a different value than `compute_short_id`). Verify no callers outside test files.
+
+**Files changed:** `firmware/src/platform/device_id.cpp`, `firmware/src/platform/device_id.h`, possibly test files.
+
+---
+
+## 6. File Reference Index
+
+| File | Role | Key lines |
+|------|------|-----------|
+| `docs/product/areas/nodetable/contract/beacon_payload_encoding_v0.md` | Canon: nodeId on-air layout | §4.1 (Core), §4.2 (Tail-1), §4.3 (Tail-2) |
+| `docs/product/areas/nodetable/contract/alive_packet_encoding_v0.md` | Canon: nodeId in Alive | §3.1 |
+| `docs/product/areas/nodetable/policy/nodetable_fields_inventory_v0.md` | Canon: ShortId row | Row "ShortId" |
+| `docs/product/areas/nodetable/index.md` | Canon hub | §2 (seq16 scope), §3 (contracts) |
+| `docs/firmware/ootb_node_table_v0.md` | OOTB-era (non-canon): collision spec | §1 (NodeID source), §1a (ShortId, collision) |
+| `docs/product/naviga_mesh_protocol_concept_v1_4.md` | Concept: mesh short_id | §3.2 (0..63 range, covered_mask), §5 (origin_id) |
+| `firmware/lib/NavigaCore/include/naviga/platform/device_id.h` | Interface: DeviceId, IDeviceIdProvider | struct definitions |
+| `firmware/src/platform/esp_device_id_provider.cpp` | Impl: eFuse MAC source | Line 16 |
+| `firmware/src/platform/device_id.cpp` | Impl: full_id_from_mac, short_id_from_mac | Lines 68–87 |
+| `firmware/src/domain/node_table.cpp` | Impl: compute_short_id, find_entry_index | Lines 62–66, 387–394 |
+| `firmware/src/app/app_services.cpp` | Wiring: ID formation entry point | Lines 147–151 |
+| `docs/product/wip/areas/nodetable/research/naviga-current-state.md` | Research: full field flow | §"Where NodeTable lives" |


### PR DESCRIPTION
## Summary

- Adds `docs/product/wip/research/nodeid_audit_s02.md` — audit of NodeID as-is state: formation chain (eFuse MAC → uint64 → CRC16 ShortId), two-concept naming collision (NodeTable ShortId uint16 vs Mesh SessionId 0..63), CRC16 discrepancy between `short_id_from_mac` and `compute_short_id`, gaps and candidate options.
- Adds `docs/product/wip/research/geo_encoding_audit_s02.md` — audit of on-air geo encoding as-is: current 24-byte codec layout vs 19-byte canon BeaconCore contract, `pos_valid`/`pos_age_s` placement gaps, mesh `origin_pos` TBD, candidate resolution options.

## Non-goals

- No code changes.
- No canon doc changes.
- No mesh/JOIN changes.
- OOTB referenced only as indicator, not as normative source.

## Quality gates

- [x] PR contains only 2 new files in `docs/product/wip/research/`
- [x] Each report has concrete file/section references
- [x] No code changes (`git diff --stat main..HEAD` shows only the 2 new docs)

## Test plan

- Review `nodeid_audit_s02.md` §3 Gaps and §5 Recommendations for accuracy.
- Review `geo_encoding_audit_s02.md` §3 Gaps (especially G1/G2 codec vs canon divergence) and §5 Recommendations for accuracy.
- Verify all file references in §6 File Reference Index of each report are correct paths.

Made with [Cursor](https://cursor.com)