### PR TITLE
Docs: Tail2 split cutover report (PR0, #313)

### DIFF
--- a/docs/product/wip/protocol/tail2_split_cutover_report.md
+++ b/docs/product/wip/protocol/tail2_split_cutover_report.md
@@ -200,7 +200,7 @@ All `Node_*` packets share the same Common prefix (see §1 invariants). Offsets 
 | 7–8 | `seq16` | Common | uint16 LE; global per-node counter |
 | 9 | `batteryPercent` | Useful payload | uint8; `0xFF` = absent |
 | 10–13 | `uptimeSec` | Useful payload | uint32 LE; `0xFFFFFFFF` = absent |
-| *(future)* | `txPowerStep` | Useful payload | planned; not in canon yet |
+| *(future)* | `txPower` | Useful payload | **planned** (S03): dynamic adaptive tx power step; requires radio layer to expose current tx power; not in canon yet |
 
 Min payload: 9 B (Common only). On-air min: 11 B. Fits LongDist budget (24 B).
 
@@ -249,6 +249,7 @@ Min payload: 9 B (Common only). On-air min: 11 B. Fits all profile budgets.
 | `maxSilence10s` | `0x04` | **`0x05`** | **Informative** | Static/config: user-set liveness hint |
 | `hwProfileId` | `0x04` | **`0x05`** | **Informative** | Static: hardware identity, set at manufacture |
 | `fwVersionId` | `0x04` | **`0x05`** | **Informative** | Static: firmware version, changes only on OTA |
+| `txPower` | *(absent today)* | `0x04` | **Operational (planned)** | Dynamic adaptive: node-self-changing; S03 once radio exposes tx power step |
 
 ### 7B) Core_Tail sequencing invariant
 
@@ -289,6 +290,7 @@ Min payload: 9 B (Common only). On-air min: 11 B. Fits all profile budgets.
 - `firmware/src/domain/node_table.h` (line 120) — Remove `has_max_silence`/`max_silence_10s`, `has_hw_profile`/`hw_profile_id`, `has_fw_version`/`fw_version_id` from `apply_tail2`; add `apply_info(node_id, seq16, has_max_silence, max_silence_10s, has_hw_profile, hw_profile_id, has_fw_version, fw_version_id, rssi_dbm, now_ms)`.
 - `firmware/src/domain/node_table.cpp` — Implement `apply_info`; update `apply_tail2` to remove moved fields.
 - `firmware/src/app/m1_runtime.cpp` (line 22) — Add `PacketLogType::INFO → "INFO"` to `packet_log_type_str()`; update `is_tail_type()` if needed.
+- *(S03 follow-up)* `firmware/protocol/tail2_codec.h` + radio platform layer — Add `txPower` field to `Tail2Fields` and `0x04` encoding once the radio adapter exposes the current tx power step; include in `build_tail2_tx` as an Operational on-change field.
 
 ### #316 — TX policy / queue fairness
 


### PR DESCRIPTION
## Summary

Adds `docs/product/wip/protocol/tail2_split_cutover_report.md` — the PR0 research map for splitting `Node_OOTB_Operational` (`0x04`) and `Node_OOTB_Informative` (`0x05`).

**No behavior changes. Docs only. One new file.**

Closes #313. Part of umbrella #318.

## What's in the report

- **Canonical alias table** (`0x01`–`0x05`) with `<Originator>_<Scope>_<Intent>` primary names and legacy `BEACON_*` parenthetical.
- **Canon inventory** (§3): exact file paths + sections for the msg_type registry, Tail-2 contract, field cadence policy, and all other canon docs with Tail-2 references.
- **WIP inventory** (§4): all WIP docs mentioning Tail-2/cadence/field composition, with relevance notes.
- **Firmware touchpoints** (§5): exact file paths and line numbers for MsgType enum, drop guard, RX dispatch, TX scheduling (currently unreachable), and existing tests.
- **Target state** (§6): fixed byte layouts for `0x04` (Operational-only) and `0x05` (Informative-only).
- **Field migration table** (§7): every Tail-2 field classified as Operational or Informative; offset shift for `0x04` documented.
- **Follow-up touch list** (§8): per-issue (#314–#317) bulleted list of file + 1-line change summary.

## Files changed

- `docs/product/wip/protocol/tail2_split_cutover_report.md` (**new**)

## Quality gates

- [x] Only `docs/` files changed
- [x] Exactly one new markdown file added
- [x] All references grounded in actual repo files (no invented filenames)
- [x] PR references #313 and #318

Made with [Cursor](https://cursor.com)