### PR TITLE
fix(beacon_logic): gate 0x04/0x05 formation on cadence interval

### DIFF
--- a/firmware/src/domain/beacon_logic.cpp
+++ b/firmware/src/domain/beacon_logic.cpp
@@ -184,7 +184,8 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
   }
 
   // ── Operational (0x04) formation ─────────────────────────────────────────
-  if (telemetry.has_battery || telemetry.has_uptime) {
+  // Guard matches Core/Alive: only enqueue when cadence interval or silence deadline is due.
+  if ((time_for_min || time_for_silence) && (telemetry.has_battery || telemetry.has_uptime)) {
     const uint16_t op_seq = next_seq16();
     protocol::Tail2Fields op{};
     op.node_id         = self_fields.node_id;
@@ -202,7 +203,8 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
   }
 
   // ── Informative (0x05) formation ─────────────────────────────────────────
-  if (telemetry.has_max_silence || telemetry.has_hw_profile || telemetry.has_fw_version) {
+  // Guard matches Core/Alive: only enqueue when cadence interval or silence deadline is due.
+  if ((time_for_min || time_for_silence) && (telemetry.has_max_silence || telemetry.has_hw_profile || telemetry.has_fw_version)) {
     const uint16_t info_seq = next_seq16();
     protocol::InfoFields info{};
     info.node_id         = self_fields.node_id;


### PR DESCRIPTION
## Problem

`update_tx_queue()` formed Operational (0x04) and Informative (0x05) packets unconditionally on every tick, ignoring `min_interval` / `max_silence` guards. This caused `seq16` to increment several times per second and filled the TX queue with stale telemetry frames — visible as rapid `S` and `T` counter increments on the OLED display.

## Fix

Wrap both formation blocks with `(time_for_min || time_for_silence)`, matching the guard already applied to Core_Pos and Alive.

## Tests

- Updated `test_beacon_logic`: tests that assumed independent formation now pass `now_ms >= min_interval_ms` so `time_for_min=true` as intended.
- All 138 native tests pass.

Closes #329

Made with [Cursor](https://cursor.com)