### PR TITLE
fix(storage): shorten NVS key role_silence_10s to 15 chars (#327)

### DIFF
--- a/firmware/src/platform/naviga_storage.cpp
+++ b/firmware/src/platform/naviga_storage.cpp
@@ -12,7 +12,7 @@ constexpr char kKeyCurrentRadio[] = "prof_cur";
 constexpr char kKeyPreviousRole[] = "role_prev";
 constexpr char kKeyPreviousRadio[] = "prof_prev";
 constexpr char kKeyProfileIntervalSec[] = "role_interval_s";
-constexpr char kKeyProfileSilence10s[] = "role_silence_10s";
+constexpr char kKeyProfileSilence10s[] = "role_silence_10";
 constexpr char kKeyProfileDistM[] = "role_dist_m";
 
 constexpr uint16_t kDefaultMinIntervalSec = 18;


### PR DESCRIPTION
## Problem

ESP32 NVS (`Preferences`) silently ignores keys longer than 15 characters — `putUInt()` returns without writing, no error is surfaced.

`"role_silence_10s"` = 16 chars → `max_silence` changes were never persisted. Every reboot loaded the default value regardless of what was set at runtime.

## Fix

Rename `"role_silence_10s"` → `"role_silence_10"` (15 chars). The `10` suffix already encodes the unit (×10 s); dropping the trailing `s` loses no information.

## Audit — all other NVS keys

| Key | Length | Status |
|---|---|---|
| `role_cur` | 8 | ✅ |
| `prof_cur` | 8 | ✅ |
| `role_prev` | 9 | ✅ |
| `prof_prev` | 9 | ✅ |
| `role_interval_s` | 15 | ✅ |
| `role_silence_10` | 15 | ✅ (was 16) |
| `role_dist_m` | 11 | ✅ |

No other keys exceed the limit.

## Note on migration

Devices with an existing NVS entry under the old key `"role_silence_10s"` will not find it under the new key — they will load the default (`max_silence = 9 × 10s = 90s`). This is acceptable: the old key was never actually written (silent fail), so there is no stored value to migrate.

Closes #327

Made with [Cursor](https://cursor.com)