### PR TITLE
Docs: PR-2 legacy/OOTB banners + Canon links (#278)

### DIFF
--- a/_working/docs_hygiene/278_pr2_inventory.md
+++ b/_working/docs_hygiene/278_pr2_inventory.md
@@ -1,0 +1,34 @@
+# PR-2 Legacy/OOTB docs inventory (#278)
+
+**Branch:** `docs/278-pr2-legacy-ootb-banners`  
+**Scope:** Add header banners + Canon link per [docs_coexistence_policy_v0.md](../../docs/product/policy/docs_coexistence_policy_v0.md). No moves/renames.
+
+---
+
+## Inventory
+
+| path | class | canon_link | action |
+|------|-------|------------|--------|
+| docs/protocols/ootb_radio_v0.md | OOTB | beacon_payload_encoding_v0, NodeTable index | banner-only ✓ |
+| docs/protocols/ootb_ble_v0.md | OOTB | (none yet) — spec_map / #15 | banner-only ✓ |
+| docs/protocols/radio_profile_presets_v0.md | OOTB | registry_radio_profiles_v0 | banner-only ✓ |
+| docs/product/ootb_radio_preset_v0.md | OOTB | registry_radio_profiles_v0, module_boot_config_v0 | banner-only ✓ |
+| docs/product/ootb_test_plan_v0.md | OOTB | field_cadence_v0; spec_map | banner-only ✓ |
+| docs/product/ootb_scope_v0.md | OOTB | (none yet) — spec_map | banner-only ✓ |
+| docs/product/ootb_gap_analysis_v0.md | OOTB | (none yet) — spec_map | banner-only ✓ |
+| docs/product/OOTB_v0_analysis_and_plan.md | OOTB | (none yet) — spec_map | banner-only ✓ |
+| docs/firmware/ootb_firmware_arch_v0.md | OOTB | boot_pipeline_v0 | banner-only ✓ |
+| docs/firmware/ootb_node_table_v0.md | OOTB | nodetable index | banner-only ✓ |
+
+**Excluded (per scope):** docs/product/areas/**, docs/product/wip/**, _working/**, docs/product/policy/ (canon process).
+
+**Note:** docs/product/ootb/** and docs/product/legacy/** are empty; in-scope files are root-level legacy/OOTB under docs/, docs/product/, docs/protocols/, docs/firmware/.
+
+---
+
+## Actions taken
+
+- **Banners added:** 10 (all OOTB).
+- **Skipped (already compliant):** 0.
+- **Needs decision:** 0 (all have either a canon link or explicit "none yet" + spec_map).
+- Banner template used: `**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [link or (none yet) — see spec_map].`

--- a/docs/firmware/ootb_firmware_arch_v0.md
+++ b/docs/firmware/ootb_firmware_arch_v0.md
@@ -1,5 +1,7 @@
 # OOTB Firmware architecture v0
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [boot_pipeline_v0](../product/areas/firmware/policy/boot_pipeline_v0.md).
+
 **Purpose:** Слои, границы и модель выполнения прошивки OOTB v0. Issue [#11](https://github.com/AlexanderTsarkov/naviga-app/issues/11).
 
 **Related:** [HAL contracts](hal_contracts_v0.md), [OOTB plan § 3.5](../product/OOTB_v0_analysis_and_plan.md), [Radio v0](../protocols/ootb_radio_v0.md), [BLE v0](../protocols/ootb_ble_v0.md).

--- a/docs/firmware/ootb_node_table_v0.md
+++ b/docs/firmware/ootb_node_table_v0.md
@@ -1,5 +1,7 @@
 # OOTB NodeTable v0 — спецификация
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [NodeTable hub](../product/areas/nodetable/index.md).
+
 **Purpose:** Структура записи о ноде, типы/единицы, правила stale, лимиты и вытеснение. Контракт с приложением по BLE. Issue [#12](https://github.com/AlexanderTsarkov/naviga-app/issues/12).
 
 **Related:** [OOTB plan](../product/OOTB_v0_analysis_and_plan.md), [OOTB BLE v0](../protocols/ootb_ble_v0.md).

--- a/docs/product/OOTB_v0_analysis_and_plan.md
+++ b/docs/product/OOTB_v0_analysis_and_plan.md
@@ -1,5 +1,7 @@
 # OOTB v0: анализ документации, план первой итерации и организация работ
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: (none yet) — see [spec_map](wip/spec_map_v0.md).
+
 Документ: анализ прочитанной продуктовой документации, понимание первой итерации (OOTB v0), подход к организации проекта и приоритизированные задачи для GitHub Projects.
 
 ---

--- a/docs/product/ootb_gap_analysis_v0.md
+++ b/docs/product/ootb_gap_analysis_v0.md
@@ -1,5 +1,7 @@
 # OOTB v0 — Gap analysis (пробелы и отложенные темы)
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: (none yet) — see [spec_map](wip/spec_map_v0.md).
+
 **Purpose:** Что не входит в seed sprint 1, но остаётся в зоне внимания проекта (owned). Issue [#8](https://github.com/AlexanderTsarkov/naviga-app/issues/8) (POC gaps/risks) и связанные.
 
 **Related:** [OOTB plan](OOTB_v0_analysis_and_plan.md), [Test Plan](ootb_test_plan_v0.md), [Workmap](../../_archive/ootb_v1/project/ootb_workmap.md).

--- a/docs/product/ootb_radio_preset_v0.md
+++ b/docs/product/ootb_radio_preset_v0.md
@@ -1,5 +1,7 @@
 # OOTB Radio preset v0 (Sprint 1 — E220/E22 UART)
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [registry_radio_profiles_v0](areas/radio/policy/registry_radio_profiles_v0.md), [module_boot_config_v0](areas/firmware/policy/module_boot_config_v0.md).
+
 **Purpose:** Зафиксировать конфигурацию радиомодуля **«из коробки»** для E220/E22 UART, используемую в Sprint 1. Отдельно различаем: **UART baud** (ESP ↔ модуль) и **Air data rate** (скорость по эфиру).
 
 **Related:** [Радио модули Навига (hardware summary)](../hardware/radio_modules_naviga.md), [POC E220 evidence](../firmware/poc_e220_evidence.md), [Radio profile presets v0](../protocols/radio_profile_presets_v0.md), [OOTB Radio v0](../protocols/ootb_radio_v0.md). Артефакт Issue #7 — см. [poc_gaps_risks.md](poc_gaps_risks.md).

--- a/docs/product/ootb_scope_v0.md
+++ b/docs/product/ootb_scope_v0.md
@@ -1,5 +1,7 @@
 # OOTB v0 — Scope & boundaries
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: (none yet) — see [spec_map](wip/spec_map_v0.md).
+
 **Purpose:** Границы OOTB v0, разбивка по спринтам и явный список того, что не входит в Sprint 1. Issue [#17](https://github.com/AlexanderTsarkov/naviga-app/issues/17).
 
 **Related:** [OOTB plan](OOTB_v0_analysis_and_plan.md), [Workmap](../../_archive/ootb_v1/project/ootb_workmap.md), [Gap analysis](ootb_gap_analysis_v0.md).

--- a/docs/product/ootb_test_plan_v0.md
+++ b/docs/product/ootb_test_plan_v0.md
@@ -1,5 +1,7 @@
 # OOTB Test Plan v0
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [field_cadence_v0](areas/nodetable/policy/field_cadence_v0.md); [spec_map](wip/spec_map_v0.md).
+
 **Purpose:** Сценарии проверки OOTB v0; что логировать и собирать для evidence. Issue [#16](https://github.com/AlexanderTsarkov/naviga-app/issues/16).
 
 **Related:** [OOTB plan](OOTB_v0_analysis_and_plan.md), [OOTB Radio v0](../protocols/ootb_radio_v0.md), [POC E220 evidence](../firmware/poc_e220_evidence.md), [Logging v0](logging_v0.md).

--- a/docs/protocols/ootb_ble_v0.md
+++ b/docs/protocols/ootb_ble_v0.md
@@ -1,5 +1,7 @@
 # OOTB BLE v0 — спецификация
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: (none yet) — see [spec_map](../product/wip/spec_map_v0.md) / [#15](https://github.com/AlexanderTsarkov/naviga-app/issues/15).
+
 **Purpose:** GATT-контракт между донглом и приложением OOTB v0: сервисы, характеристики, форматы. Issue [#15](https://github.com/AlexanderTsarkov/naviga-app/issues/15).
 
 **Related:** [OOTB plan](../product/OOTB_v0_analysis_and_plan.md), [NodeTable v0](../firmware/ootb_node_table_v0.md), [Radio v0](ootb_radio_v0.md).

--- a/docs/protocols/ootb_radio_v0.md
+++ b/docs/protocols/ootb_radio_v0.md
@@ -1,5 +1,7 @@
 # OOTB Radio v0 — спецификация
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [beacon payload & NodeTable](../product/areas/nodetable/contract/beacon_payload_encoding_v0.md), [NodeTable hub](../product/areas/nodetable/index.md).
+
 **Purpose:** Формат и правила радиоканала OOTB v0 (GEO_BEACON, дефолты, пресеты). Issue [#14](https://github.com/AlexanderTsarkov/naviga-app/issues/14).
 
 **Related:** [Radio profile presets v0](radio_profile_presets_v0.md), [ADR radio band strategy](../adr/radio_band_strategy_v0.md).

--- a/docs/protocols/radio_profile_presets_v0.md
+++ b/docs/protocols/radio_profile_presets_v0.md
@@ -1,5 +1,7 @@
 # Radio profile presets v0 (OOTB)
 
+**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [registry_radio_profiles_v0](../product/areas/radio/policy/registry_radio_profiles_v0.md).
+
 **Purpose:** Формализовать «продуктовые пресеты» радиосвязи так, чтобы UART-модули (E22/E220) и будущие SPI-модули могли быть совместимы на уровне конфига. Пользователь и протокол оперируют абстракциями, не сырыми LoRa-параметрами.
 
 **Related:** [ADR radio band strategy](../adr/radio_band_strategy_v0.md), [OOTB Radio v0](ootb_radio_v0.md).


### PR DESCRIPTION
## Goal

Execute **PR-2** for [#278](https://github.com/AlexanderTsarkov/naviga-app/issues/278): create legacy/OOTB docs inventory and add header banners + "Canon: [link]" per [docs_coexistence_policy_v0.md](docs/product/policy/docs_coexistence_policy_v0.md). Banner-in-place only; no moves/renames.

## Report

| Count | Value |
|-------|--------|
| **Banners added** | 10 |
| **Skipped (already compliant)** | 0 |
| **Needs decision** | 0 |

**Inventory:** [_working/docs_hygiene/278_pr2_inventory.md](_working/docs_hygiene/278_pr2_inventory.md) — path | class | canon_link | action for all in-scope files.

## Scope

- **Target:** OOTB-named and root-level legacy docs under `docs/protocols/`, `docs/product/` (root), `docs/firmware/`. `docs/product/ootb/` and `docs/product/legacy/` are empty.
- **Excluded:** `docs/product/areas/**`, `docs/product/wip/**`, `_working/` (evidence), `docs/product/policy/` (canon process).
- **Banner template:** `**Status:** Non-normative (OOTB). As-implemented v0 reference. May diverge from canon. Canon: [link or (none yet) — see spec_map].`
- Where no single canon doc exists: `Canon: (none yet) — see [spec_map](wip/spec_map_v0.md)` (or issue link).

## Files changed

- **protocols:** ootb_radio_v0.md, ootb_ble_v0.md, radio_profile_presets_v0.md
- **product:** ootb_radio_preset_v0.md, ootb_test_plan_v0.md, ootb_scope_v0.md, ootb_gap_analysis_v0.md, OOTB_v0_analysis_and_plan.md
- **firmware:** ootb_firmware_arch_v0.md, ootb_node_table_v0.md
- **New:** _working/docs_hygiene/278_pr2_inventory.md

No structural changes. Advances #278 (PR-2 checkbox).

Made with [Cursor](https://cursor.com)