### PR TITLE
Docs: unify archive semantics — canonical archive/iterations (#278)

### DIFF
--- a/_archive/README.md
+++ b/_archive/README.md
@@ -1,0 +1,3 @@
+# Legacy archive prefix
+
+**Canonical archive root is [archive/](../archive/).** This folder (`_archive`) is kept for backward compatibility and existing links. New iteration snapshots live under **archive/iterations/**; other long-term archives (POC, templates) live under **archive/** per [archive/README.md](../archive/README.md).

--- a/_archive/iterations/README.md
+++ b/_archive/iterations/README.md
@@ -1,0 +1,6 @@
+# Iterations (legacy location)
+
+**DEPRECATED — use [archive/iterations](../../archive/iterations).** This folder (`_archive/iterations`) exists only to preserve existing links (e.g. to S01 and any snapshot indexes). The **canonical** location for iteration snapshots and archiving rules is **`archive/iterations/`** at repo root.
+
+- **Canonical rule:** Create and use **`archive/iterations/`** at repo root (see that folder’s README when present).
+- **Current iteration workspace:** [\_working/README.md](../../_working/README.md) — on close, archive to `archive/iterations/<ITERATION_ID>/`.

--- a/_working/README.md
+++ b/_working/README.md
@@ -1,6 +1,6 @@
 # Working — current implementation iteration
 
-`_working/` is the workspace for the **current implementation iteration** and its verification artifacts. **Issue existence is not the classifier; Work Area is.** Only **Work Area = Implementation** (with Test artifacts allowed) uses the iteration concept; Product Specs WIP has no iteration and lives in `docs/product/wip/**`.
+`_working/` is the **volatile sandbox** for the **current implementation iteration** and its verification artifacts. When an iteration is closed, the archive snapshot/index lives under **[archive/iterations/](../archive/iterations/)** (canonical). **Issue existence is not the classifier; Work Area is.** Only **Work Area = Implementation** (with Test artifacts allowed) uses the iteration concept; Product Specs WIP has no iteration and lives in `docs/product/wip/**`.
 
 ## ITERATION.md contract
 
@@ -10,7 +10,7 @@
 
 ## Allowed in _working
 
-- **Work Area = Implementation:** working notes, spike results, logs, investigations that support the current iteration. After merge, archive to `_archive/iterations/<ITERATION_ID>/` where `<ITERATION_ID>` is the **first line** of [ITERATION.md](ITERATION.md).
+- **Work Area = Implementation:** working notes, spike results, logs, investigations that support the current iteration. On iteration close, archive snapshot/index to **[archive/iterations/<ITERATION_ID>/](../archive/iterations/)** where `<ITERATION_ID>` is the **first line** of [ITERATION.md](ITERATION.md).
 - **Work Area = Test:** test results, logs, measurements that support the current iteration.
 
 Research outputs for the current iteration go under `_working/research/` (see CLAUDE.md Research artifacts policy).


### PR DESCRIPTION
## Goal

Unify archive semantics: **`archive/iterations`** is the single canonical iterations archive. `_archive/iterations` is explicitly deprecated and points to `archive/iterations`; `_working` lifecycle references `archive/iterations` on iteration close. No file moves.

## Changes

- **\_working/README.md** — `_working` is the volatile sandbox for the current iteration; on iteration close, archive snapshot/index lives in **archive/iterations/<ITERATION_ID>/** (canonical). Updated “Allowed” to point there.
- **\_archive/iterations/README.md** (new) — **DEPRECATED — use archive/iterations.** This folder kept only to preserve existing links (e.g. S01). Canonical rule: create/use `archive/iterations/` at repo root.
- **\_archive/README.md** (new) — Canonical archive root is `archive/`; `_archive` kept for backward compatibility. New iteration snapshots under **archive/iterations/**.

No structural changes; README/policy text only. Follow-up hygiene for [#278](https://github.com/AlexanderTsarkov/naviga-app/issues/278).

Made with [Cursor](https://cursor.com)