### PR TITLE
S03: Use P3 throttling for Operational/Informative + hybrid expired_counter

### DIFF
--- a/docs/product/wip/areas/nodetable/policy/packet_sets_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/packet_sets_v0_1.md
@@ -72,7 +72,7 @@ The following v0 canon layouts were read from the **existing contracts** (read-o
 | **Option 1** | Keep **u16** for hw_profile_id and fw_version_id in Informative v0.1. Payload size and LoRa step thresholds remain as in v0. No mapping table. |
 | **Option 2** | Introduce **compact u8 aliases** for v0.1 only (e.g. hw_profile_id_u8, fw_version_id_u8) with a **mapping table** from registry to u8. Wire format would then differ from v0; requires explicit contract update and migration path. |
 
-**Action:** Choose Option 1 or Option 2 in the PR / issue; add a TODO checkbox. Do **not** implement a width change without an explicit decision.
+**Decided:** Keep **hwProfileId** and **fwVersionId** as **uint16 LE (2 B each)** in Informative layout. Option 1. Conflict closed. [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351), [#364](https://github.com/AlexanderTsarkov/naviga-app/issues/364).
 
 ### 4.3 Naming and supersession (Tail-1 / position quality)
 
@@ -81,7 +81,13 @@ The following v0 canon layouts were read from the **existing contracts** (read-o
 
 ---
 
-## 5) Related
+## 5) Implementation (FW alignment)
+
+Firmware matches this policy: **Core_Pos** and **Alive** use P0; **Node_Core_Tail** (Tail1) uses P2; **Node_Operational** and **Node_Informative** use P3. The hybrid **expired_counter** is implemented as `replaced_count` in the TX queue: +1 on replacement by same coalesce_key, +1 when due/eligible but not sent (starvation), reset on send, preserved across replacement. Intra-priority ordering uses `replaced_count` DESC. Implementation status: implemented in FW; tabletop validation deferred. [#364](https://github.com/AlexanderTsarkov/naviga-app/issues/364), [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365).
+
+---
+
+## 6) Related
 
 - [tx_priority_and_arbitration_v0_1.md](tx_priority_and_arbitration_v0_1.md) — P0–P3, coalesce_key, expired_counter.
 - [beacon_payload_encoding_v0.md](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) — Canon payload layouts.

--- a/docs/product/wip/areas/nodetable/policy/tx_priority_and_arbitration_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/tx_priority_and_arbitration_v0_1.md
@@ -17,6 +17,8 @@ This document defines the **v0.1 intent** for TX priority levels, coalesce keys,
 
 Within the same priority, packets are ordered by **expired_counter DESC** (see §3).
 
+**FW implementation:** Operational (0x04) and Informative (0x05) are enqueued at **P3_THROTTLED** in firmware; Core_Tail (Tail1) remains P2; Core_Pos and Alive remain P0. Selection order is P0 > P1 > P2 > P3. Implementation status: implemented in FW; tabletop validation deferred. [#364](https://github.com/AlexanderTsarkov/naviga-app/issues/364), [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365).
+
 ---
 
 ## 2) Coalesce key

--- a/docs/protocols/ootb_radio_v0.md
+++ b/docs/protocols/ootb_radio_v0.md
@@ -196,19 +196,19 @@ The firmware TX queue assigns each pending packet type a **priority class**. At 
 |-------|-----------|---------|----------------------|
 | **P0** | `P0_MUST_PERIODIC` | Mandatory periodic. Must not be starved. Drives liveness and position. | `Node_OOTB_Core_Pos` (0x01), `Node_OOTB_I_Am_Alive` (0x02) |
 | **P1** | `P1_SESSION_MESH` | **Reserved.** Future Session/Mesh control packets (e.g. `Node_Session_*`, Mesh relay control). NOT used by any current OOTB packet type. | *(none today)* |
-| **P2** | `P2_BEST_EFFORT` | Best-effort delivery. Sub-ordered by `TxBestEffortClass` (see below). | `Node_OOTB_Core_Tail` (0x03), `Node_OOTB_Operational` (0x04), `Node_OOTB_Informative` (0x05) |
-| **P3** | `P3_THROTTLED` | **Reserved.** Opportunistic / channel-utilization-throttled traffic. Sent only when no P0–P2 slots are pending and channel budget allows. | *(none today)* |
+| **P2** | `P2_BEST_EFFORT` | Best-effort delivery. Sub-ordered by `TxBestEffortClass` (see below). | `Node_OOTB_Core_Tail` (0x03) |
+| **P3** | `P3_THROTTLED` | Opportunistic / channel-utilization-throttled. Sent when no P0–P2 slots are pending and channel budget allows. | `Node_OOTB_Operational` (0x04), `Node_OOTB_Informative` (0x05) |
 
-> **Current OOTB packets use P0 and P2 only.** P1 is reserved for future Session/Mesh control packets. P3 is reserved for throttled opportunistic traffic.
+> **Current OOTB packets use P0 (Core_Pos, Alive), P2 (Core_Tail), and P3 (Operational, Informative).** P1 is reserved for future Session/Mesh control packets. Implementation: [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365); tabletop validation deferred.
 
 #### Best-effort sub-priority (`TxBestEffortClass`)
 
-Within `P2_BEST_EFFORT`, slots are further ordered by `be_rank`:
+Within `P2_BEST_EFFORT` only (Core_Tail); P3 slots are not sub-ranked by `be_rank`:
 
 | `be_rank` | Code name | Packet types | Rationale |
 |-----------|-----------|--------------|-----------|
-| **BE_HIGH** | `BE_HIGH` | `Node_OOTB_Core_Tail` (0x03) | Time-bound to its Core sample; send before Operational/Informative to maximise Core_Tail usefulness. |
-| **BE_LOW** | `BE_LOW` | `Node_OOTB_Operational` (0x04), `Node_OOTB_Informative` (0x05) | Slow-state; equal sub-priority; fairness via `replaced_count` / `created_at_ms`. |
+| **BE_HIGH** | `BE_HIGH` | `Node_OOTB_Core_Tail` (0x03) | Time-bound to its Core sample; P2 so it is sent before P3 (Operational/Informative). |
+| *(P3)* | — | `Node_OOTB_Operational` (0x04), `Node_OOTB_Informative` (0x05) | P3_THROTTLED; fairness via `replaced_count` / `created_at_ms`. |
 
 #### Full selection order (dequeue)
 
@@ -232,9 +232,9 @@ The priority classes map to the delivery tiers in [field_cadence_v0.md](../produ
 |-----------------------|-----------------|
 | Tier A (Core/Alive) | P0_MUST_PERIODIC |
 | Tier B (Core_Tail) | P2_BEST_EFFORT / BE_HIGH |
-| Tier C (Operational, Informative) | P2_BEST_EFFORT / BE_LOW |
+| Tier C (Operational, Informative) | P3_THROTTLED |
 
-The degrade-under-load order in field_cadence_v0 §4 (keep Tier A, reduce Tier B, drop Tier C first) is enforced by this priority + be_rank ordering.
+The degrade-under-load order in field_cadence_v0 §4 (keep Tier A, reduce Tier B, drop Tier C first) is enforced by this priority ordering (P0 > P2 > P3).
 
 ---
 

--- a/firmware/src/domain/beacon_logic.cpp
+++ b/firmware/src/domain/beacon_logic.cpp
@@ -197,7 +197,7 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
     uint8_t op_frame[protocol::kTail2FrameMax] = {};
     const size_t op_len = protocol::encode_tail2_frame(op, op_frame, sizeof(op_frame));
     if (op_len > 0) {
-      enqueue_slot(kSlotTail2, TxPriority::P2_BEST_EFFORT, TxBestEffortClass::BE_LOW,
+      enqueue_slot(kSlotTail2, TxPriority::P3_THROTTLED, TxBestEffortClass::BE_LOW,
                    PacketLogType::TAIL2, op_frame, op_len, now_ms, 0);
     }
   }
@@ -218,7 +218,7 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
     uint8_t info_frame[protocol::kInfoFrameMax] = {};
     const size_t info_len = protocol::encode_info_frame(info, info_frame, sizeof(info_frame));
     if (info_len > 0) {
-      enqueue_slot(kSlotInfo, TxPriority::P2_BEST_EFFORT, TxBestEffortClass::BE_LOW,
+      enqueue_slot(kSlotInfo, TxPriority::P3_THROTTLED, TxBestEffortClass::BE_LOW,
                    PacketLogType::INFO, info_frame, info_len, now_ms, 0);
     }
   }
@@ -235,8 +235,8 @@ bool BeaconLogic::dequeue_tx(uint8_t* out,
   *out_len = 0;
 
   // Selection order (lower value = higher priority in each dimension):
-  //   1. TxPriority (primary)
-  //   2. TxBestEffortClass be_rank (secondary; only meaningful within P2_BEST_EFFORT)
+  //   1. TxPriority (primary): P0 > P1 > P2 > P3
+  //   2. TxBestEffortClass be_rank (within P2 only; P3 slots use BE_LOW)
   //   3. replaced_count descending (most-starved first)
   //   4. created_at_ms ascending (oldest first)
   int best = -1;
@@ -287,7 +287,15 @@ bool BeaconLogic::dequeue_tx(uint8_t* out,
   if (out_type)     { *out_type     = slot.pkt_type; }
   if (out_core_seq) { *out_core_seq = slot.ref_core_seq16; }
 
-  // Clear the slot.
+  // Starvation increment: every other present slot was due but not sent this round.
+  const size_t best_u = static_cast<size_t>(best);
+  for (size_t i = 0; i < kTxSlotCount; ++i) {
+    if (i != best_u && slots_[i].present) {
+      slots_[i].replaced_count++;
+    }
+  }
+
+  // Clear the selected slot (reset on send).
   slot = TxSlot{};
 
   return true;

--- a/firmware/src/domain/beacon_logic.h
+++ b/firmware/src/domain/beacon_logic.h
@@ -35,56 +35,44 @@ enum class PacketLogType {
  *                       (e.g. Node_Session_*, Mesh_P0 relay control).
  *                       NOT used by any current OOTB packet type.
  *
- *   P2_BEST_EFFORT    — Best-effort delivery. Ordering within P2 is determined by
- *                       TxBestEffortClass (be_rank): BE_HIGH before BE_LOW, then
- *                       replaced_count (desc), then created_at_ms (asc).
- *                       Current users:
- *                         BE_HIGH — Node_OOTB_Core_Tail (0x03)
- *                         BE_LOW  — Node_OOTB_Operational (0x04), Node_OOTB_Informative (0x05)
+ *   P2_BEST_EFFORT    — Best-effort delivery. Ordering within P2 by replaced_count (desc),
+ *                       then created_at_ms (asc). Current user: Node_OOTB_Core_Tail (0x03).
  *
- *   P3_THROTTLED      — Opportunistic / channel-utilization-throttled traffic.
- *                       Sent only when no P0–P2 slots are pending and channel budget allows.
- *                       Reserved; no current packet type uses this level.
+ *   P3_THROTTLED      — Opportunistic; throttled first under load. Ordering within P3 by
+ *                       replaced_count (desc), then created_at_ms (asc).
+ *                       Current users: Node_OOTB_Operational (0x04), Node_OOTB_Informative (0x05).
  */
 enum class TxPriority : uint8_t {
   P0_MUST_PERIODIC = 0,  ///< Mandatory periodic; Core_Pos + I_Am_Alive.
   P1_SESSION_MESH  = 1,  ///< Reserved: future Session/Mesh control. NOT used today.
   P2_BEST_EFFORT   = 2,  ///< Best-effort; sub-ordered by TxBestEffortClass.
-  P3_THROTTLED     = 3,  ///< Reserved: throttled/opportunistic. NOT used today.
+  P3_THROTTLED     = 3,  ///< Opportunistic; Operational (0x04), Informative (0x05).
 };
 
 /**
  * Sub-priority within P2_BEST_EFFORT (lower value = higher sub-priority).
- *
- * Ordering within the same TxPriority::P2_BEST_EFFORT bucket:
- *   1. be_rank (BE_HIGH before BE_LOW)
- *   2. replaced_count descending (most-starved first)
- *   3. created_at_ms ascending (oldest first)
- *
- * Mapping:
- *   BE_HIGH — Node_OOTB_Core_Tail (0x03): time-bound to its Core sample; send before
- *             Operational/Informative to maximise Core_Tail usefulness.
- *   BE_LOW  — Node_OOTB_Operational (0x04), Node_OOTB_Informative (0x05): slow-state;
- *             fairness between them via replaced_count / created_at_ms.
+ * Only Core_Tail uses P2; be_rank is BE_HIGH for Tail1. P3 slots use BE_LOW for
+ * comparator tie-break (within P3, ordering is by replaced_count desc, created_at_ms asc).
  */
 enum class TxBestEffortClass : uint8_t {
-  BE_HIGH = 0,  ///< Core_Tail (0x03).
-  BE_LOW  = 1,  ///< Operational (0x04), Informative (0x05).
+  BE_HIGH = 0,  ///< Core_Tail (0x03) in P2.
+  BE_LOW  = 1,  ///< Used for P3 slots in comparator (same rank within P3).
 };
 
 /**
  * One pending TX frame slot.
  *
- * Slots are keyed by packet type (one slot per type). Replacement increments
- * replaced_count and preserves created_at_ms so fairness accounting is correct.
+ * Slots are keyed by packet type (one slot per type). replaced_count is the
+ * hybrid expired_counter: +1 on replacement, +1 when starved (due but not sent),
+ * reset when slot is sent (cleared), preserved across replacement.
  */
 struct TxSlot {
   bool     present        = false;
   TxPriority priority     = TxPriority::P2_BEST_EFFORT;
-  TxBestEffortClass be_rank = TxBestEffortClass::BE_LOW;  ///< Sub-priority within P2_BEST_EFFORT.
+  TxBestEffortClass be_rank = TxBestEffortClass::BE_LOW;  ///< P2: BE_HIGH for Tail1; P3: BE_LOW.
   PacketLogType pkt_type  = PacketLogType::CORE;
   uint32_t created_at_ms  = 0;   ///< Set when slot first becomes present; preserved on replace.
-  uint32_t replaced_count = 0;   ///< Incremented each time slot is replaced before being sent.
+  uint32_t replaced_count = 0;   ///< expired_counter: +1 replace, +1 starved, reset on send.
   uint16_t ref_core_seq16 = 0;   ///< For TAIL1 only: the Core_Pos seq16 this tail supplements.
   uint8_t  frame[protocol::kMaxFrameSize] = {};
   size_t   frame_len = 0;

--- a/firmware/test/test_beacon_logic/test_beacon_logic.cpp
+++ b/firmware/test/test_beacon_logic/test_beacon_logic.cpp
@@ -1339,7 +1339,7 @@ void test_txq_dequeue_empty_returns_false() {
 }
 
 void test_txq_dequeue_core_before_operational() {
-  // Core (P0) must be dequeued before Operational (P2).
+  // Core (P0) must be dequeued before Operational (P3).
   BeaconLogic logic;
   logic.set_min_interval_ms(1000);
   logic.set_max_silence_ms(30000);
@@ -1369,7 +1369,7 @@ void test_txq_dequeue_core_before_operational() {
 }
 
 void test_txq_dequeue_tail1_before_operational() {
-  // Tail-1 (P2/BE_HIGH) must be dequeued before Operational (P2/BE_LOW).
+  // Tail-1 (P2) must be dequeued before Operational (P3).
   BeaconLogic logic;
   logic.set_min_interval_ms(1000);
   logic.set_max_silence_ms(30000);
@@ -1389,7 +1389,7 @@ void test_txq_dequeue_tail1_before_operational() {
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::CORE), static_cast<int>(ptype));
 
-  // Now Tail-1 (P1) and Operational (P2) remain. Tail-1 should be next.
+  // Now Tail-1 (P2) and Operational (P3) remain. Tail-1 should be next.
   TEST_ASSERT_TRUE(logic.slot(kSlotTail1).present);
   TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);
 
@@ -1399,7 +1399,7 @@ void test_txq_dequeue_tail1_before_operational() {
 }
 
 void test_txq_fairness_higher_replaced_count_wins() {
-  // Within same priority (P2), the slot with higher replaced_count is dequeued first.
+  // Within same priority (P3), the slot with higher replaced_count is dequeued first.
   BeaconLogic logic;
   logic.set_min_interval_ms(1000);   // cadence due at t=1000, 2000, 3000
   logic.set_max_silence_ms(120000);
@@ -1414,6 +1414,8 @@ void test_txq_fairness_higher_replaced_count_wins() {
   logic.update_tx_queue(1000, self, telem_op, false);  // time_for_min=true
   TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);
   TEST_ASSERT_EQUAL_UINT32(0, logic.slot(kSlotTail2).replaced_count);
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P3_THROTTLED),
+                    static_cast<int>(logic.slot(kSlotTail2).priority));
 
   // Enqueue Informative once (replaced_count=0).
   SelfTelemetry telem_info{};
@@ -1428,7 +1430,7 @@ void test_txq_fairness_higher_replaced_count_wins() {
   logic.update_tx_queue(3000, self, telem_op, false);  // time_for_min=true
   TEST_ASSERT_EQUAL_UINT32(1, logic.slot(kSlotTail2).replaced_count);
 
-  // Both P2 slots present. Operational has replaced_count=1, Info has replaced_count=0.
+  // Both P3 slots present. Operational has replaced_count=1, Info has replaced_count=0.
   // Operational should be dequeued first (higher replaced_count = more starved).
   uint8_t buf[65] = {};
   size_t out_len = 0;
@@ -1442,7 +1444,7 @@ void test_txq_fairness_higher_replaced_count_wins() {
 }
 
 void test_txq_fairness_older_created_at_wins_on_tie() {
-  // Within same priority and same replaced_count, older created_at_ms wins.
+  // Within same priority (P3) and same replaced_count, older created_at_ms wins.
   BeaconLogic logic;
   logic.set_min_interval_ms(1000);   // cadence due at t=1000, 2000
   logic.set_max_silence_ms(120000);
@@ -1462,7 +1464,7 @@ void test_txq_fairness_older_created_at_wins_on_tie() {
   telem_info.max_silence_10s = 9;
   logic.update_tx_queue(2000, self, telem_info, false);  // time_for_min=true
 
-  // Both replaced_count=0, same priority. Operational (older) should win.
+  // Both replaced_count=0, same priority (P3). Operational (older) should win.
   uint8_t buf[65] = {};
   size_t out_len = 0;
   PacketLogType ptype = PacketLogType::INFO;
@@ -1685,9 +1687,8 @@ void test_txq_p1_never_assigned_in_formation() {
   }
 }
 
-void test_txq_be_high_beats_be_low_within_p2() {
-  // Within P2_BEST_EFFORT, Core_Tail (BE_HIGH) must be dequeued before
-  // Operational (BE_LOW) and Informative (BE_LOW), regardless of creation order.
+void test_txq_p2_tail1_before_p3_operational_informative() {
+  // Core_Tail (P2) must be dequeued before Operational (P3) and Informative (P3).
   BeaconLogic logic;
   logic.set_min_interval_ms(500);    // cadence due at t=500 for Op/Info
   logic.set_max_silence_ms(120000);
@@ -1695,7 +1696,7 @@ void test_txq_be_high_beats_be_low_within_p2() {
   const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
   GeoBeaconFields self = make_self_fields(node_id, true);
 
-  // Enqueue Operational and Informative first (older created_at_ms).
+  // Enqueue Operational and Informative first (P3).
   SelfTelemetry telem{};
   telem.has_battery     = true;
   telem.battery_percent = 90;
@@ -1704,24 +1705,20 @@ void test_txq_be_high_beats_be_low_within_p2() {
   logic.update_tx_queue(500, self, telem, false);  // time_for_min=true
   TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);
   TEST_ASSERT_TRUE(logic.slot(kSlotInfo).present);
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P3_THROTTLED),
+                    static_cast<int>(logic.slot(kSlotTail2).priority));
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P3_THROTTLED),
+                    static_cast<int>(logic.slot(kSlotInfo).priority));
   TEST_ASSERT_FALSE(logic.slot(kSlotTail1).present);
 
-  // Now enqueue Core_Tail directly by triggering a Core formation.
-  // Use a fresh logic instance to isolate; instead, manually verify be_rank.
-  // Verify the slot's be_rank directly.
-  TEST_ASSERT_EQUAL(static_cast<int>(TxBestEffortClass::BE_LOW),
-                    static_cast<int>(logic.slot(kSlotTail2).be_rank));
-  TEST_ASSERT_EQUAL(static_cast<int>(TxBestEffortClass::BE_LOW),
-                    static_cast<int>(logic.slot(kSlotInfo).be_rank));
-
-  // Now also enqueue a Core (and thus Core_Tail) at t=1000.
+  // Now enqueue Core (and thus Core_Tail) at t=1000.
   logic.set_min_interval_ms(1000);
   logic.set_max_silence_ms(30000);
   SelfTelemetry telem2{};
   logic.update_tx_queue(1000, self, telem2, true);
   TEST_ASSERT_TRUE(logic.slot(kSlotTail1).present);
-  TEST_ASSERT_EQUAL(static_cast<int>(TxBestEffortClass::BE_HIGH),
-                    static_cast<int>(logic.slot(kSlotTail1).be_rank));
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P2_BEST_EFFORT),
+                    static_cast<int>(logic.slot(kSlotTail1).priority));
 
   // Dequeue Core (P0) first.
   uint8_t buf[65] = {};
@@ -1730,14 +1727,39 @@ void test_txq_be_high_beats_be_low_within_p2() {
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::CORE), static_cast<int>(ptype));
 
-  // Next: Core_Tail (P2/BE_HIGH) even though Operational/Info have older created_at_ms.
+  // Next: Core_Tail (P2) even though Operational/Info (P3) have older created_at_ms.
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::TAIL1), static_cast<int>(ptype));
 }
 
+void test_txq_starvation_increments_replaced_count() {
+  // When we dequeue one slot, every other present slot gets +1 replaced_count (starvation).
+  BeaconLogic logic;
+  logic.set_min_interval_ms(1000);
+  logic.set_max_silence_ms(30000);
+
+  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
+  GeoBeaconFields self = make_self_fields(node_id, true);
+  SelfTelemetry telem{};
+  telem.has_battery = true;
+  telem.battery_percent = 90;
+
+  logic.update_tx_queue(1000, self, telem, true);
+  TEST_ASSERT_TRUE(logic.slot(kSlotCore).present);
+  TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);
+  TEST_ASSERT_EQUAL_UINT32(0, logic.slot(kSlotTail2).replaced_count);
+
+  uint8_t buf[65] = {};
+  size_t out_len = 0;
+  logic.dequeue_tx(buf, sizeof(buf), &out_len);
+  // Core was dequeued; Tail2 was present but not sent → starvation +1.
+  TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);
+  TEST_ASSERT_EQUAL_UINT32(1, logic.slot(kSlotTail2).replaced_count);
+}
+
 void test_txq_priority_ordering_p0_beats_all() {
-  // Verify full ordering: P0 > P2/BE_HIGH > P2/BE_LOW with all 5 slots present.
-  // P1 and P3 are reserved and not assigned by formation.
+  // Verify full ordering: P0 > P2 > P3 with all 5 slots present.
+  // P1 is reserved; Operational and Informative are P3.
   BeaconLogic logic;
   logic.set_min_interval_ms(1000);
   logic.set_max_silence_ms(30000);
@@ -1754,9 +1776,13 @@ void test_txq_priority_ordering_p0_beats_all() {
   logic.update_tx_queue(1000, self, telem, true);
 
   TEST_ASSERT_TRUE(logic.slot(kSlotCore).present);   // P0
-  TEST_ASSERT_TRUE(logic.slot(kSlotTail1).present);  // P2/BE_HIGH
-  TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);  // P2/BE_LOW
-  TEST_ASSERT_TRUE(logic.slot(kSlotInfo).present);   // P2/BE_LOW
+  TEST_ASSERT_TRUE(logic.slot(kSlotTail1).present);   // P2
+  TEST_ASSERT_TRUE(logic.slot(kSlotTail2).present);  // P3
+  TEST_ASSERT_TRUE(logic.slot(kSlotInfo).present);   // P3
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P3_THROTTLED),
+                    static_cast<int>(logic.slot(kSlotTail2).priority));
+  TEST_ASSERT_EQUAL(static_cast<int>(TxPriority::P3_THROTTLED),
+                    static_cast<int>(logic.slot(kSlotInfo).priority));
 
   uint8_t buf[65] = {};
   size_t out_len = 0;
@@ -1766,18 +1792,18 @@ void test_txq_priority_ordering_p0_beats_all() {
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::CORE), static_cast<int>(ptype));
 
-  // 2nd dequeue: Core_Tail (P2_BEST_EFFORT / BE_HIGH).
+  // 2nd dequeue: Core_Tail (P2_BEST_EFFORT).
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
   TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::TAIL1), static_cast<int>(ptype));
 
-  // 3rd and 4th dequeue: P2/BE_LOW (Operational and Informative, order by fairness).
+  // 3rd and 4th dequeue: P3 (Operational and Informative, order by fairness).
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
-  const bool third_is_be_low = (ptype == PacketLogType::TAIL2 || ptype == PacketLogType::INFO);
-  TEST_ASSERT_TRUE(third_is_be_low);
+  const bool third_is_p3 = (ptype == PacketLogType::TAIL2 || ptype == PacketLogType::INFO);
+  TEST_ASSERT_TRUE(third_is_p3);
 
   logic.dequeue_tx(buf, sizeof(buf), &out_len, &ptype);
-  const bool fourth_is_be_low = (ptype == PacketLogType::TAIL2 || ptype == PacketLogType::INFO);
-  TEST_ASSERT_TRUE(fourth_is_be_low);
+  const bool fourth_is_p3 = (ptype == PacketLogType::TAIL2 || ptype == PacketLogType::INFO);
+  TEST_ASSERT_TRUE(fourth_is_p3);
 
   TEST_ASSERT_FALSE(logic.has_pending_tx());
 }
@@ -1861,9 +1887,10 @@ int main(int argc, char** argv) {
   // TX queue: Informative replacement + dequeue (gap coverage)
   RUN_TEST(test_txq_informative_replacement_increments_count);
   RUN_TEST(test_txq_informative_dequeued_correctly);
-  // TX queue: P1 reserved; be_rank ordering; full priority ordering
+  // TX queue: P1 reserved; P2 vs P3 ordering; starvation; full priority ordering
   RUN_TEST(test_txq_p1_never_assigned_in_formation);
-  RUN_TEST(test_txq_be_high_beats_be_low_within_p2);
+  RUN_TEST(test_txq_p2_tail1_before_p3_operational_informative);
+  RUN_TEST(test_txq_starvation_increments_replaced_count);
   RUN_TEST(test_txq_priority_ordering_p0_beats_all);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **Firmware:** Operational (0x04) and Informative (0x05) are enqueued at **P3_THROTTLED**; Core_Tail (0x03) at P2; Core_Pos/Alive at P0. Hybrid **expired_counter** (`replaced_count`): +1 on replacement and on starvation, reset on send, preserved across replacement.
- **Docs:** `ootb_radio_v0.md` — P2/P3 table and Tier C mapping updated; implementation status + [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365). WIP policy docs: FW implementation note, implementation status (tabletop deferred), [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365). HW/FW decision (uint16 LE) unchanged and conflict closed in packet_sets.

## Tests run

- `pio run -e devkit_e22_oled_gnss` — **SUCCESS**
- `pio test -e test_native -f test_beacon_logic` — **67/67 PASSED**

## Tabletop validation deferred

- [ ] Two-node tabletop: both nodes exchange Core_Pos, Tail, Operational, Informative without decode errors.
- [ ] Confirm in logs/debug that Operational/Informative are P3 and throttled first under load.

Tracked in [#365](https://github.com/AlexanderTsarkov/naviga-app/issues/365).

---

Refs #365 #351 #352 #364.
