### PR TITLE
S03 WIP: add NodeTable Field Map v0.1 entry doc

### DIFF
--- a/docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md
@@ -1,0 +1,102 @@
+# NodeTable Field Map v0.1 — single entry for #352 / S03 slice
+
+**Status:** WIP. Authoritative **single entry point** for NodeTable field-level reference under [#352](https://github.com/AlexanderTsarkov/naviga-app/issues/352). **Parent:** [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351), [#352](https://github.com/AlexanderTsarkov/naviga-app/issues/352).
+
+This doc is the **field-level index** only. It does not duplicate the field table; it declares the master table as source of truth, explains how to read it, and links to policy docs and S03 slice. No semantic or field changes; documentation and links only.
+
+---
+
+## 1) Purpose
+
+- **Single entry** for #352 and the S03 NodeTable slice: one place to find the field-level source of truth and how it relates to WIP policy and execution.
+- Enables closing #352 without losing traceability: master table + this index + slice doc + execution issues form the chain.
+
+---
+
+## 2) Source of truth (MUST be explicit)
+
+- **fields_v0_1.csv** and **nodetable_master_table_v0_1.xlsx** are the **field-level source of truth** for NodeTable fields (and packets/sources in the same artifact set).
+- They are **generated** by **build_master_table.py** (deterministic). The generator inputs live in that script; do not edit the CSV/XLSX by hand for field definitions.
+
+| Artifact | Role |
+|----------|------|
+| [master_table/fields_v0_1.csv](../master_table/fields_v0_1.csv) | Field rows (machine-readable) |
+| [master_table/nodetable_master_table_v0_1.xlsx](../master_table/nodetable_master_table_v0_1.xlsx) | Same data + packets + sources (human-friendly sheets) |
+| [master_table/tools/build_master_table.py](../master_table/tools/build_master_table.py) | Generator; edit this to change fields, then regenerate |
+
+---
+
+## 3) How to read the master table (brief)
+
+Key columns in the **Fields** sheet / **fields_v0_1.csv**:
+
+| Column | Meaning |
+|--------|---------|
+| **field_key** | Canonical field name (e.g. node_id, seq16, last_rx_rssi). |
+| **scope_class** | Core / Injected / Derived / etc. |
+| **status** | Canon, CodeNow, WIP, Superseded, Idea, etc. |
+| **owner** | NodeOwned, ReceiverInjected, Derived, Config, etc. |
+| **producer_status** / **source** | Implemented | Stubbed | Planned; HW | Derived | Injected | Config — who produces the value. |
+| **sent_on_air** / **packet_name_canon** / **wire_bytes_fixed** | On-air: whether sent, in which packet, fixed byte size. |
+| **exported_over_ble** | Whether the field is in the BLE snapshot (and **ble_record_offset** / **ble_bytes** if so). |
+| **notes** | Semantics, update rules, contract refs, S03 scope notes. |
+
+Use **field_key** + **status** + **notes** for implementation and traceability; use **on_air_contract_ref** and **packet_name_canon** for encoding contracts.
+
+---
+
+## 4) S03 scope lock
+
+- The bounded S03 NodeTable scope (what is in/out, execution issues, promotion rule) is defined in the **S03 slice** doc.
+- **Link:** [slices/s03_nodetable_slice_v0_1.md](../slices/s03_nodetable_slice_v0_1.md).
+
+---
+
+## 5) Policy references
+
+Field semantics and update rules are defined in WIP policy docs; the master table rows reference them via **on_air_contract_ref** and **notes**. Key policy docs:
+
+| Policy | Content |
+|--------|---------|
+| [identity_naming_persistence_eviction_v0_1.md](identity_naming_persistence_eviction_v0_1.md) | Identity, node_name, persistence/eviction scope. |
+| [presence_and_age_semantics_v0_1.md](presence_and_age_semantics_v0_1.md) | last_seen_ms, last_seen_age_s, is_stale, pos_age_s. |
+| [seq_ref_version_link_metrics_v0_1.md](seq_ref_version_link_metrics_v0_1.md) | seq16/ref_core_seq16, last_payload_version_seen, last_rx_rssi, snrLast. |
+| [packet_sets_v0_1.md](packet_sets_v0_1.md) | Packet types, payloads, eligibility. |
+| [tx_priority_and_arbitration_v0_1.md](tx_priority_and_arbitration_v0_1.md) | P0–P3, expired_counter, TX queue. |
+
+---
+
+## 6) Out-of-scope reminders (short)
+
+- **networkName**, **ownership/claim**, **over-air name propagation** — not in S03.
+- **activityState**, **PositionQuality**, **aliveStatus** — WIP-only / policy-derived; not promoted to S03 first-class; UI uses is_stale, last_seen_age_s, pos_age_s, posFlags/sats.
+
+---
+
+## 7) Execution mapping
+
+Issues that must be completed (or explicitly deferred) for S03; one-line purpose each:
+
+| Issue | Purpose |
+|-------|---------|
+| [#367](https://github.com/AlexanderTsarkov/naviga-app/issues/367) | FW: NodeTable persistence v1 + eviction v1 (NVS snapshot, restore, tier-aware eviction). |
+| [#368](https://github.com/AlexanderTsarkov/naviga-app/issues/368) | FW/BLE: self node_name read/write + NVS persistence (self-only). |
+| [#369](https://github.com/AlexanderTsarkov/naviga-app/issues/369) | App: local phone name storage + authoritative-replaces-local rule (optional). |
+| [#371](https://github.com/AlexanderTsarkov/naviga-app/issues/371) | grace_s value and placement (FW/app/both). |
+| [#372](https://github.com/AlexanderTsarkov/naviga-app/issues/372) | Self presence TX update points (which TX counts as presence for self). |
+| [#375](https://github.com/AlexanderTsarkov/naviga-app/issues/375) | FW: Parse E22 RSSI append, update last_rx_rssi in NodeTable. |
+| [#376](https://github.com/AlexanderTsarkov/naviga-app/issues/376) | FW: snrLast NA/UNSUPPORTED sentinel, plumb through snapshots. |
+
+---
+
+## 8) Promotion to canon rule
+
+**WIP → canon after:** (1) docs merged to canon paths, (2) linked execution issues implemented (or explicitly deferred), (3) tabletop checklist satisfied where applicable. Align with [s03_nodetable_slice_v0_1.md](../slices/s03_nodetable_slice_v0_1.md) §5.
+
+---
+
+## 9) How to update
+
+- **Do not** edit the CSV or XLSX by hand for field definitions.
+- **Do:** change the generator inputs in **build_master_table.py** (FIELDS_ROWS, FIELD_DEFAULTS, SOURCES_ROWS as needed) → run the script → commit the regenerated **fields_v0_1.csv**, **nodetable_master_table_v0_1.xlsx**, **sources_v0_1.csv** (and **packets_v0_1.csv** if changed).
+- Update **references** (e.g. policy doc links, this field map, slice) only when paths or scope change; no manual table edits in markdown.

--- a/docs/product/wip/areas/nodetable/slices/s03_nodetable_slice_v0_1.md
+++ b/docs/product/wip/areas/nodetable/slices/s03_nodetable_slice_v0_1.md
@@ -13,10 +13,11 @@ This document is the **index/slice** for the S03 NodeTable scope. It consolidate
 
 ---
 
-## 2) Source of truth (links)
+## 2) Source of truth / Entry points
 
 | What | Location |
 |------|----------|
+| **Field-level entry** (master table index) | [policy/nodetable_field_map_v0_1.md](../policy/nodetable_field_map_v0_1.md) — single entry for #352; declares CSV/XLSX as field truth. |
 | Identity, naming, persistence, eviction | [policy/identity_naming_persistence_eviction_v0_1.md](../policy/identity_naming_persistence_eviction_v0_1.md) |
 | Presence and age (is_stale, last_seen_age_s, pos_age_s) | [policy/presence_and_age_semantics_v0_1.md](../policy/presence_and_age_semantics_v0_1.md) |
 | Seq, ref, payload version, link metrics | [policy/seq_ref_version_link_metrics_v0_1.md](../policy/seq_ref_version_link_metrics_v0_1.md) |


### PR DESCRIPTION
## Summary

**No semantic changes; only entry doc + links.**

- **New:** [nodetable_field_map_v0_1.md](docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md) — single entry point for #352 / S03 NodeTable slice:
  - Explicitly declares **fields_v0_1.csv** and **nodetable_master_table_v0_1.xlsx** as field-level source of truth (generated by build_master_table.py).
  - How to read key columns (field_key, scope_class, status, owner, producer_status/source, sent_on_air/packet_name_canon/wire_bytes_fixed, exported_over_ble, notes).
  - Link to [S03 slice](docs/product/wip/areas/nodetable/slices/s03_nodetable_slice_v0_1.md); policy refs (identity/naming/persistence, presence, seq/ref/link-metrics, packet_sets, tx_priority); out-of-scope reminders; execution mapping (#367, #368, #369, #371, #372, #375, #376); promotion rule; how to update (generator only).
- **Updated:** [s03_nodetable_slice_v0_1.md](docs/product/wip/areas/nodetable/slices/s03_nodetable_slice_v0_1.md) — added link to Field Map in "Source of truth / Entry points".

Docs-only; no master-table artifact changes.

Refs #352 #351.

---

**After merge — comment template for #352:**

```
Field Map doc added at `docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md`; master table (fields_v0_1.csv / nodetable_master_table_v0_1.xlsx) is field-level truth; S03 slice locked at `docs/product/wip/areas/nodetable/slices/s03_nodetable_slice_v0_1.md`; execution tracked in #367, #368, #369, #371, #372, #375, #376.
```

Made with [Cursor](https://cursor.com)