### PR TITLE
docs(#384): TX power contract — baseline, runtime, override (S03)

### DIFF
--- a/docs/product/wip/areas/radio/policy/radio_profiles_model_s03.md
+++ b/docs/product/wip/areas/radio/policy/radio_profiles_model_s03.md
@@ -11,7 +11,7 @@ This doc defines the **product-level RadioProfile data model** and **NVS storage
 
 - **Purpose:** Define product-level profile fields, pointer semantics (default/current/previous), baseline vs runtime separation, and NVS schema (namespace, keys, versioning) so that Phase A can apply FACTORY default at boot without NVS, Phase B can persist pointers/records for rollback and future UI, and S04 can list/read/select/create profiles against this schema.
 - **Scope:** Schema and model only; no BLE protocol, no UI, no SPI driver implementation. Mapping to E220 UART (and later SPI) is documented as notes; adapter layer owns the mapping.
-- **Non-goals:** No automatic TX power control algorithms; no JOIN/Mesh/CAD/LBT. Runtime telemetry vs baseline contract is in [#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384); UART mapping spec is [#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383).
+- **Non-goals:** No automatic TX power control algorithms; no JOIN/Mesh/CAD/LBT. Runtime telemetry vs baseline contract is in [tx_power_contract_s03.md](tx_power_contract_s03.md) ([#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384)); UART mapping spec is [#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383).
 
 ---
 
@@ -82,7 +82,7 @@ Existing implementation uses **prof_cur** and **prof_prev** in the same namespac
 ## 5) Baseline vs runtime separation
 
 - **Baseline:** The stored profile content (channel_slot, rate_tier, tx_power_baseline_step) that is applied to the module at boot or when the user selects a profile. It is **not** mutated by runtime behavior (e.g. RSSI on RX, or module readback of actual TX power).
-- **Runtime:** Values observed at runtime (e.g. last TX power read back from module, last_rx_rssi, snr). Used for telemetry and NodeTable/display only. **Must not** overwrite the persisted profile baseline. See [#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384) for the contract.
+- **Runtime:** Values observed at runtime (e.g. last TX power read back from module, last_rx_rssi, snr). Used for telemetry and NodeTable/display only. **Must not** overwrite the persisted profile baseline. See [tx_power_contract_s03.md](tx_power_contract_s03.md) ([#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384)) for the contract.
 
 ---
 
@@ -131,5 +131,5 @@ No BLE protocol or UI is defined here; only that the storage and model support t
 - **Boot pipeline:** [boot_pipeline_v0](../../../areas/firmware/policy/boot_pipeline_v0.md) — Phase A applies FACTORY default; Phase B persists pointers/records.
 - **Module boot config:** [module_boot_config_v0](../../../areas/firmware/policy/module_boot_config_v0.md) — module-critical vs profile-applied; FACTORY default applied in Phase A.
 - **Provisioning interface:** [provisioning_interface_v0](../../../areas/firmware/policy/provisioning_interface_v0.md) — role/radio get/set/reset; writes pointers.
-- **UART mapping spec:** [#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383). **TX power contract (baseline vs runtime):** [#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384).
+- **UART mapping spec:** [#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383). **TX power contract (baseline vs runtime):** [tx_power_contract_s03.md](tx_power_contract_s03.md) ([#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384)).
 - **Current NVS impl:** `firmware/src/platform/naviga_storage.{h,cpp}` — namespace `naviga`, keys prof_cur, prof_prev. Product-level struct **RadioProfileRecord** (profile_id, kind, channel_slot, rate_tier, tx_power_baseline_step, label) and **get_factory_default_radio_profile()** added for schema alignment (#382); rprof_ver and USER profile load/save can be added in follow-up. Constants: **kRadioProfileSchemaVersion**, **kRadioProfileIdFactoryDefault**.

--- a/docs/product/wip/areas/radio/policy/tx_power_contract_s03.md
+++ b/docs/product/wip/areas/radio/policy/tx_power_contract_s03.md
@@ -1,0 +1,75 @@
+# Radio — TX power contract: baseline, runtime, override (S03)
+
+**Status:** WIP (spec).  
+**Issue:** [#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384) · **Epic:** [#353](https://github.com/AlexanderTsarkov/naviga-app/issues/353) · **Umbrella:** [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351)
+
+This doc defines the **TX power contract** that separates **baseline** (stored in RadioProfile, read/write via future BLE/UI), **runtime** (current effective setting), and **reserved** override semantics for future adaptive/automatic escalation—**without** changing baseline. No algorithms are implemented; only a future-safe contract. Aligns with [radio_profiles_model_s03.md](radio_profiles_model_s03.md) ([#382](https://github.com/AlexanderTsarkov/naviga-app/issues/382)), [e220_radio_profile_mapping_s03.md](e220_radio_profile_mapping_s03.md) ([#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383)), [boot_pipeline_v0](../../../areas/firmware/policy/boot_pipeline_v0.md), and [module_boot_config_v0](../../../areas/firmware/policy/module_boot_config_v0.md).
+
+---
+
+## 1) Purpose and scope
+
+- **Purpose:** Define terms and invariants so that (a) profile baseline TX power is the single source of truth for “user choice,” (b) runtime may diverge in future (e.g. adaptive escalation) without mutating baseline, and (c) override semantics are reserved for future use. Support observability (baseline + runtime + override state) and embedded fault handling.
+- **Scope:** Contract and policy only; no code, no BLE protocol/UI design, no automatic TX power algorithm implementation (only reserved semantics).
+- **Non-goals:** No JOIN/Mesh/CAD/LBT; no implementation of adaptive escalation in S03.
+
+---
+
+## 2) Terms
+
+| Term | Meaning |
+|------|--------|
+| **baseline_tx_power_step** | TX power step **stored** in the active RadioProfile (e.g. `RadioProfileRecord.tx_power_baseline_step`). Read/write via future BLE/UI; UI may hide but **must** remain writable for provisioning and diagnostics. Source of truth for “user/profile choice.” |
+| **runtime_tx_power_step** | The **actual current** backend (module) setting. May equal baseline or, in future, differ (e.g. after adaptive escalation). Not persisted as profile content; may be unknown if backend does not support readback. |
+| **effective_tx_power_step** | The step **used for TX** at any moment. In S03: equals runtime when known, else baseline. In future: may be subject to override (see below). |
+| **override_active** | **(RESERVED)** Future flag: when true, effective TX power is temporarily above baseline (e.g. adaptive escalation). **Not implemented** in S03; semantics reserved so that baseline is never overwritten by runtime/adaptive behavior. |
+| **override_reason** | **(RESERVED)** Future enum or code (e.g. “session missing,” “addressed request”). **Not implemented** in S03. |
+
+**Note:** The RadioProfile model uses the field name `tx_power_baseline_step`; it is the stored baseline. This contract uses **baseline_tx_power_step** as the conceptual term; they refer to the same value.
+
+---
+
+## 3) Invariants
+
+1. **Boot:** Apply **baseline** from the active profile to the radio. OOTB FACTORY default uses **step 0 = MIN** (21 dBm) per [e220_radio_profile_mapping_s03.md](e220_radio_profile_mapping_s03.md) ([#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383)) and [boot_pipeline_v0](../../../areas/firmware/policy/boot_pipeline_v0.md) Phase A.
+2. **Baseline mutability:** Baseline is changed **only** by profile write, profile switch, or factory reset. **Never** by runtime behavior, adaptive logic, or module readback.
+3. **Runtime vs baseline:** Runtime may change in future (e.g. adaptive escalation). Runtime **must not** overwrite or persist to the profile baseline. When override is cleared or on reboot, effective reverts to baseline unless future policy says otherwise.
+4. **Reboot behavior:** On reboot, **default to baseline**; any runtime override is cleared. Effective TX power after boot is the baseline from the active profile (or FACTORY default on first boot). Future policy may define explicit “persist override until…”; for S03, reboot clears any reserved override state.
+
+---
+
+## 4) Observability and telemetry requirements
+
+- The system **must** expose:
+  - **Baseline:** Current profile’s baseline TX power step (from `RadioProfileRecord` or equivalent).
+  - **Runtime:** Current effective/runtime TX power step, or **unknown** if the backend does not support readback or readback failed.
+  - **override_active:** **(Reserved)** Exposed for future use; in S03 always false / not implemented.
+- **Embedded fault handling:** If backend read or apply of TX power fails (e.g. E220 write/readback failure), the device must **continue best-effort** (no brick) and set a **diag flag** (observable fault state) per [module_boot_config_v0](../../../areas/firmware/policy/module_boot_config_v0.md) §4. Telemetry may report runtime = unknown and/or a fault code; baseline remains unchanged.
+
+---
+
+## 5) Backend notes
+
+- **E220 UART:** Step mapping and OOTB MIN requirement are defined in [e220_radio_profile_mapping_s03.md](e220_radio_profile_mapping_s03.md) ([#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383)). Power-level count differs by module: T30D = 4 levels, T33D = 5 levels; clamp rules apply. Same baseline/runtime/override contract holds.
+- **SPI (later):** Driver-defined step-to-dBm mapping; **same contract** (baseline stored in profile, runtime may differ, no overwrite of baseline; override semantics reserved).
+
+---
+
+## 6) Future note: adaptive escalation (out of scope for S03)
+
+**Planned use-case (non-goal for S03):** In a future iteration, the system may implement **adaptive TX power escalation**—e.g. when a session or an important node is missing, stepwise increase of effective TX power (within hardware limits) plus addressed request, then step back down when link is restored. This contract reserves semantics so that:
+
+- **Baseline** stays the stored user/profile choice and is **never** overwritten by adaptive behavior.
+- **Runtime** / **effective** may temporarily exceed baseline while **override_active** (and optionally **override_reason**) are set.
+- On reboot or when override is cleared, effective reverts to baseline.
+
+No algorithm is specified or implemented in S03; only the contract is defined to keep baseline authoritative and future-safe.
+
+---
+
+## 7) Related
+
+- **RadioProfile model:** [radio_profiles_model_s03.md](radio_profiles_model_s03.md) ([#382](https://github.com/AlexanderTsarkov/naviga-app/issues/382)) — `tx_power_baseline_step` in profile; baseline vs runtime separation.
+- **E220 mapping:** [e220_radio_profile_mapping_s03.md](e220_radio_profile_mapping_s03.md) ([#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383)) — step-to-dBm mapping, OOTB MIN.
+- **Boot:** [boot_pipeline_v0](../../../areas/firmware/policy/boot_pipeline_v0.md) (Phase A apply FACTORY default; Phase B pointers).
+- **Failure/observable fault:** [module_boot_config_v0](../../../areas/firmware/policy/module_boot_config_v0.md) §4 — RepairFailed, best-effort, diag flag.


### PR DESCRIPTION
## Summary
Documents the TX power contract that supports baseline (stored in RadioProfile, read/write via future BLE/UI), runtime (current effective), and reserved override semantics for future adaptive escalation without changing baseline. No algorithms; future-safe contract only.

## Deliverables
- **New:** `docs/product/wip/areas/radio/policy/tx_power_contract_s03.md` — terms (baseline_tx_power_step, runtime_tx_power_step, effective_tx_power_step, override_active/override_reason reserved), invariants (boot apply baseline, OOTB MIN, baseline only by profile write/switch/reset, reboot default to baseline), observability + fault handling, backend notes (E220/SPI), future adaptive-escalation note (out of scope S03).
- **Edit:** `radio_profiles_model_s03.md` — link to contract doc in §1, §5, §9.

## Quality
- Docs-only; no code changes. Consistent with OOTB MIN and Phase A/B boot policy.

Closes #384.

Made with [Cursor](https://cursor.com)