### PR TITLE
docs(#358): Packet → NodeTable mapping (S03)

### DIFF
--- a/docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/nodetable_field_map_v0_1.md
@@ -63,6 +63,7 @@ Field semantics and update rules are defined in WIP policy docs; the master tabl
 | [seq_ref_version_link_metrics_v0_1.md](seq_ref_version_link_metrics_v0_1.md) | seq16/ref_core_seq16, last_payload_version_seen, last_rx_rssi, snrLast. |
 | [packet_sets_v0_1.md](packet_sets_v0_1.md) | Packet types, payloads, eligibility. |
 | [tx_priority_and_arbitration_v0_1.md](tx_priority_and_arbitration_v0_1.md) | P0–P3, expired_counter, TX queue. |
+| [packet_to_nodetable_mapping_s03.md](packet_to_nodetable_mapping_s03.md) ([#358](https://github.com/AlexanderTsarkov/naviga-app/issues/358)) | Packet → NodeTable mapping (S03): which packet updates which fields, gating, presence (#371, #372). |
 
 ---
 

--- a/docs/product/wip/areas/nodetable/policy/packet_to_nodetable_mapping_s03.md
+++ b/docs/product/wip/areas/nodetable/policy/packet_to_nodetable_mapping_s03.md
@@ -1,0 +1,130 @@
+# NodeTable — Packet → NodeTable mapping (S03)
+
+**Status:** WIP. S03 planning doc. **Issue:** [#358](https://github.com/AlexanderTsarkov/naviga-app/issues/358) · **Umbrella:** [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351).
+
+This doc is the **canonical S03 planning reference** for which packets update which NodeTable fields, with gating/conditions and ties to presence rules (#371 grace_s, #372 self TX). It uses the [NodeTable master table](../master_table/README.md) ([fields_v0_1.csv](../master_table/fields_v0_1.csv), [packets_v0_1.csv](../master_table/packets_v0_1.csv)) as **source of truth** and points to encoding contracts without redefining them. No new fields or packet semantics; documentation only.
+
+---
+
+## 1) Scope, sources, non-goals
+
+- **Scope (S03):** Map the five on-air packet types (Alive, Node_Core_Pos, Node_Core_Tail, Node_Operational, Node_Informative) to NodeTable field updates; include gating (GNSS fix, self vs remote, Core/Tail pairing); tie in presence/staleness rules. Doc-only; no firmware/code changes.
+- **Sources of truth:** [master_table/README.md](../master_table/README.md), [fields_v0_1.csv](../master_table/fields_v0_1.csv), [packets_v0_1.csv](../master_table/packets_v0_1.csv). Every mapping claim in this doc traces to a packet or field row in those artifacts (or a linked contract).
+- **Non-goals:** No BLE/UI protocol; no JOIN/Mesh/CAD/LBT; no new fields or packets; no redefinition of encoding semantics — only summarize and link.
+
+---
+
+## 2) Packet inventory (from packets_v0_1.csv)
+
+| Packet (canon) | Legacy | Purpose | Gating (from packets_v0_1) | Encoding contract |
+|----------------|--------|---------|----------------------------|-------------------|
+| **Alive** | BEACON_ALIVE | No-fix liveness; identity + seq16 only. Alive-bearing, non-position-bearing. | When no fix, within maxSilence | [alive_packet_encoding_v0](../../../../areas/nodetable/contract/alive_packet_encoding_v0.md); [beacon_payload_encoding_v0](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) §3 |
+| **Node_Core_Pos** | BEACON_CORE | Minimal WHO+WHERE. Core only with valid fix. | Only with valid GNSS fix | [beacon_payload_encoding_v0](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) §4.1 |
+| **Node_Core_Tail** | BEACON_TAIL1 | Core-attached extension; qualifies one Core sample. | ref_core_seq16 must match lastCoreSeq; when position valid | [tail1_packet_encoding_v0](../../../../areas/nodetable/contract/tail1_packet_encoding_v0.md) §3 |
+| **Node_Operational** | BEACON_TAIL2 | Dynamic runtime: battery, uptime. | No CoreRef; on change + at forced Core | [tail2_packet_encoding_v0](../../../../areas/nodetable/contract/tail2_packet_encoding_v0.md) §3.2 |
+| **Node_Informative** | BEACON_INFO | Static/config: maxSilence, hwProfileId, fwVersionId. | On change + every 10 min; MUST NOT send on every Operational | [info_packet_encoding_v0](../../../../areas/nodetable/contract/info_packet_encoding_v0.md) §3.2 |
+
+---
+
+## 3) Mapping: packet → fields updated
+
+For each packet, **fields updated** when the payload is applied (RX for remote entry; for **self**, see §4 — only presence-bearing TX update self last_seen_ms; payload fields for self are updated when we **send** that packet and write to self entry). **Source** = RX (receiver applies from wire), **NodeOwned** (from payload), **Injected** (receiver-side on RX). **Gating** from packets_v0_1.csv and field notes. Consumer location: NodeEntry (in_node_entry_struct), BLE snapshot (exported_over_ble), on-air (sent_on_air) per fields_v0_1.csv.
+
+### 3.1 Common (all Node_* packets)
+
+On **any** accepted Node_* packet (Alive, Core_Pos, Core_Tail, Operational, Informative), the receiver updates:
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| node_id | RX (payload) | NodeEntry, BLE, on-air | All packets carry node_id (beacon_payload_encoding_v0 §3). |
+| payloadVersion | RX (payload) | Debug/injected only (last_payload_version_seen) | First byte of payload; not persisted as user-facing. |
+| seq16 | RX (payload) | NodeEntry (last_seq), BLE | Dedupe key; last_seq updates on any RX. |
+
+**Receiver-injected on any RX** (not from payload; from RX event): **last_seen_ms** (presence anchor), **last_rx_rssi** (when RSSI available). See [presence_and_age_semantics_v0_1.md](presence_and_age_semantics_v0_1.md) §1; [seq_ref_version_link_metrics_v0_1.md](seq_ref_version_link_metrics_v0_1.md).
+
+### 3.2 Alive
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| (common: node_id, seq16) | RX | NodeEntry, BLE, on-air | — |
+| aliveStatus | RX (payload, optional) | — | S03: stubbed/unused; not in NodeTable/BLE (fields_v0_1: Stubbed). |
+
+**Gating:** Sent when **no GNSS fix**, within maxSilence. **Remote:** RX updates last_seen_ms (presence). **Self:** TX of Alive **updates self last_seen_ms** (presence-bearing per §4). Does **not** update position or pos_age_s (non-position-bearing).
+
+### 3.3 Node_Core_Pos
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| (common: node_id, seq16) | RX | NodeEntry, BLE, on-air | — |
+| positionLat, positionLon | RX (payload) | NodeEntry (lat_e7, lon_e7), BLE | **Only with valid GNSS fix.** Core-only sample. |
+| last_core_seq16 (stored) | RX (payload seq16) | NodeEntry; used for Tail ref match | Updated **only** on Core_Pos RX (Tail apply uses ref_core_seq16 match). |
+
+**Gating:** **Only with valid GNSS fix**; every beacon tick when position valid. **Remote:** RX updates last_seen_ms, position, last_core_seq16. **Self:** TX of Core_Pos updates **self** position fields and **pos_age_s** (only position-bearing packet for self); TX **updates self last_seen_ms** (presence-bearing per §4). Encoding: [beacon_payload_encoding_v0](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) §4.1.
+
+### 3.4 Node_Core_Tail
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| (common: node_id, seq16) | RX | NodeEntry, BLE, on-air | — |
+| ref_core_seq16 | RX (payload) | NodeEntry (link to Core sample) | **ref_core_seq16 must match lastCoreSeq** (Tail applies to that Core). |
+| posFlags, sats | RX (payload, optional) | NodeEntry | Qualifies Core sample; Tail-1 only. |
+
+**Receiver-injected on Tail RX when applied:** **last_applied_tail_ref_core_seq16** (dedupe; at most one Tail per Core per seq_ref_version_link_metrics_v0_1).
+
+**Gating:** Every Tail-1 when position valid; **ref_core_seq16 must match lastCoreSeq**. **Remote:** RX updates last_seen_ms; payload updates ref_core_seq16, posFlags, sats. **Self:** TX of Core_Tail **updates self last_seen_ms** (presence-bearing, paired with Core per §4); does **not** update pos_age_s (no new lat/lon). Encoding: [tail1_packet_encoding_v0](../../../../areas/nodetable/contract/tail1_packet_encoding_v0.md) §3.
+
+### 3.5 Node_Operational
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| (common: node_id, seq16) | RX | NodeEntry, BLE, on-air | — |
+| batteryPercent, uptimeSec | RX (payload, optional) | NodeEntry, BLE | On change + at forced Core; no CoreRef. |
+
+**Gating:** No CoreRef; cadence on-change + at forced Core. **Remote:** RX updates last_seen_ms (any packet) and Operational fields from payload. **Self:** TX of Operational does **not** update self last_seen_ms (non–presence-bearing per §4); payload updates self NodeEntry Operational fields when we send. Encoding: [tail2_packet_encoding_v0](../../../../areas/nodetable/contract/tail2_packet_encoding_v0.md) §3.2.
+
+### 3.6 Node_Informative
+
+| Field | Source | Consumer | Gating |
+|-------|--------|----------|--------|
+| (common: node_id, seq16) | RX | NodeEntry, BLE, on-air | — |
+| maxSilence10s, hwProfileId, fwVersionId | RX (payload, optional) | NodeEntry | On change + every 10 min; MUST NOT send on every Operational. |
+
+**Gating:** Static/config; cadence on-change + every 10 min. **Remote:** RX updates last_seen_ms and Informative fields. **Self:** TX of Informative does **not** update self last_seen_ms (non–presence-bearing per §4); payload updates self NodeEntry Informative fields when we send. **maxSilence10s** is the source for **expected_interval_s** (presence/staleness). Encoding: [info_packet_encoding_v0](../../../../areas/nodetable/contract/info_packet_encoding_v0.md) §3.2.
+
+---
+
+## 4) Presence and staleness summary
+
+- **expected_interval_s and grace_s (#371):**  
+  `expected_interval_s = max_silence_10s * 10`; `grace_s = clamp(3, 30, round(expected_interval_s * 0.10))` (seconds); `is_stale = (last_seen_age_s > expected_interval_s + grace_s)`. FW-owned; not user-configurable. Source: [presence_and_age_semantics_v0_1.md](presence_and_age_semantics_v0_1.md) §2.
+
+- **Self presence TX update set (#372):**  
+  **Update self last_seen_ms:** Node_Alive, Node_Core_Pos, Node_Core_Tail (Tail when sent — paired with Core). **Do NOT update self last_seen_ms:** Node_Operational, Node_Informative. **pos_age_s for self:** Updated **only** on Node_Core_Pos TX (position-bearing). Source: [presence_and_age_semantics_v0_1.md](presence_and_age_semantics_v0_1.md) §1.D.
+
+- **Interaction:** For **remote** entries, any accepted Node_* RX updates last_seen_ms. For **self**, only presence-bearing TX (Alive, Core_Pos, Core_Tail) update last_seen_ms. **last_seen_age_s** and **is_stale** are derived at export from last_seen_ms and expected_interval_s + grace_s. max_silence liveness is satisfied by sending Alive or Core_Pos (and Core_Tail when sent with Core); Operational/Informative do not satisfy liveness.
+
+---
+
+## 5) Persistence notes (from master table)
+
+- **Persisted (Y in fields_v0_1):** node_id, positionLat/Lon (lat_e7, lon_e7), seq16/last_seq, ref_core_seq16/last_core_seq16, fwVersionId, hwProfileId, maxSilence10s, batteryPercent, uptimeSec, sats, posFlags, last_seen_ms (internal; BLE exports last_seen_age_s derived), last_rx_rssi, and other NodeEntry members per CSV **persistence_notes** (e.g. BLE snapshot, in NodeEntry). See fields_v0_1.csv columns **persisted**, **persistence_notes**.
+- **Not persisted / RAM-only (or derived at export):** last_seen_age_s, is_stale (computed at export); last_payload_version_seen (debug only); some Injected/Derived per CSV. **WIP/Planned** fields may not yet have persistence implemented; master table **persistence_notes** and **producer_status** indicate current state. This doc does not add new persistence; only reflects the table.
+
+---
+
+## 6) Cross-links
+
+| Doc / issue | Description |
+|-------------|-------------|
+| [#358](https://github.com/AlexanderTsarkov/naviga-app/issues/358) | This task (Packet → NodeTable mapping). |
+| [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351) | S03 umbrella planning. |
+| [NodeTable master table](../master_table/README.md) | [fields_v0_1.csv](../master_table/fields_v0_1.csv), [packets_v0_1.csv](../master_table/packets_v0_1.csv) — source of truth. |
+| [presence_and_age_semantics_v0_1.md](presence_and_age_semantics_v0_1.md) | grace_s (§2), self presence TX (§1.D); #371, #372. |
+| [ootb_autonomous_start_s03.md](../../firmware/policy/ootb_autonomous_start_s03.md) | Boot-time packet start; when we start sending what (§5). |
+| [provisioning_baseline_s03.md](../../firmware/policy/provisioning_baseline_s03.md) | Phase A/B inputs (role, radio profile); what feeds NodeTable config. |
+| [beacon_payload_encoding_v0](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) | Common payload; Core position. |
+| [alive_packet_encoding_v0](../../../../areas/nodetable/contract/alive_packet_encoding_v0.md) | Alive payload. |
+| [tail1_packet_encoding_v0](../../../../areas/nodetable/contract/tail1_packet_encoding_v0.md) | Core_Tail payload. |
+| [tail2_packet_encoding_v0](../../../../areas/nodetable/contract/tail2_packet_encoding_v0.md) | Operational payload. |
+| [info_packet_encoding_v0](../../../../areas/nodetable/contract/info_packet_encoding_v0.md) | Informative payload. |
+| [nodetable_field_map_v0_1.md](nodetable_field_map_v0_1.md) | Field-level index for #352; master table as field truth. |


### PR DESCRIPTION
## Goal
Close #358 by creating the canonical S03 planning doc **Packet → NodeTable mapping**.

## Changes
- **New:** `docs/product/wip/areas/nodetable/policy/packet_to_nodetable_mapping_s03.md`
  - §1 Scope, sources of truth (master_table fields_v0_1 + packets_v0_1), non-goals.
  - §2 Packet inventory from packets_v0_1.csv (Alive, Node_Core_Pos, Node_Core_Tail, Node_Operational, Node_Informative) with gating and encoding contract links.
  - §3 Mapping: for each packet, fields updated, source (RX/NodeOwned/Injected), gating, consumer (NodeEntry/BLE/on-air); common (node_id, seq16, last_seen_ms); per-packet tables; ties to presence (#371, #372).
  - §4 Presence and staleness summary: expected_interval_s + grace_s (#371), self presence TX set (#372), interaction with last_seen_ms/last_seen_age_s/is_stale.
  - §5 Persistence notes from master table (persisted vs RAM-only/derived).
  - §6 Cross-links: master table, presence_and_age, ootb_autonomous_start, provisioning_baseline, encoding contracts (beacon, alive, tail1, tail2, info), nodetable_field_map.
- **Edit:** `nodetable_field_map_v0_1.md` §5: add Related link to packet_to_nodetable_mapping_s03.md (#358).

No new semantics; all claims trace to fields_v0_1.csv, packets_v0_1.csv, or linked contracts. Presence section reflects finalized #371/#372 rules.

Closes #358.

Made with [Cursor](https://cursor.com)