### PR TITLE
docs: finalize #407 WIP packet context / TX rules snapshot

### DIFF
--- a/docs/product/wip/areas/nodetable/policy/packet_sets_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/packet_sets_v0_1.md
@@ -92,6 +92,7 @@ Firmware matches this policy: **Core_Pos** and **Alive** use P0; **Node_Core_Tai
 ## 6) Related
 
 - [tx_priority_and_arbitration_v0_1.md](tx_priority_and_arbitration_v0_1.md) — P0–P3, coalesce_key, expired_counter.
+- [packet_context_tx_rules_v0_1.md](../../radio/policy/packet_context_tx_rules_v0_1.md) ([#407](https://github.com/AlexanderTsarkov/naviga-app/issues/407)) — Agreed v0.2 packet context and TX rules (Node_Pos_Full, Node_Status).
 - [beacon_payload_encoding_v0.md](../../../../areas/nodetable/contract/beacon_payload_encoding_v0.md) — Canon payload layouts.
 - [tail1_packet_encoding_v0.md](../../../../areas/nodetable/contract/tail1_packet_encoding_v0.md), [tail2_packet_encoding_v0.md](../../../../areas/nodetable/contract/tail2_packet_encoding_v0.md), [info_packet_encoding_v0.md](../../../../areas/nodetable/contract/info_packet_encoding_v0.md) — Canon v0 contracts.
 - [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351), [#352](https://github.com/AlexanderTsarkov/naviga-app/issues/352).

--- a/docs/product/wip/areas/nodetable/policy/tx_priority_and_arbitration_v0_1.md
+++ b/docs/product/wip/areas/nodetable/policy/tx_priority_and_arbitration_v0_1.md
@@ -54,5 +54,6 @@ Within the same priority, packets are ordered by **expired_counter DESC** (see �
 
 - [identity_naming_persistence_eviction_v0_1.md](identity_naming_persistence_eviction_v0_1.md) — S03 Identity/Naming + Persistence/Eviction block (frozen).
 - [packet_sets_v0_1.md](packet_sets_v0_1.md) — Packet definitions v0.1 and eligibility rules.
+- [packet_context_tx_rules_v0_1.md](../../radio/policy/packet_context_tx_rules_v0_1.md) ([#407](https://github.com/AlexanderTsarkov/naviga-app/issues/407)) — Agreed v0.2 packet context and TX rules (Node_Pos_Full, Node_Status).
 - [field_cadence_v0.md](field_cadence_v0.md) — Canon tiers and cadence.
 - [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351), [#352](https://github.com/AlexanderTsarkov/naviga-app/issues/352).

--- a/docs/product/wip/areas/radio/policy/channel_utilization_budgeting_and_profile_strategy_s03_v0_1.md
+++ b/docs/product/wip/areas/radio/policy/channel_utilization_budgeting_and_profile_strategy_s03_v0_1.md
@@ -108,6 +108,7 @@ Exact values and role IDs from [role_profiles_policy_v0](../../../../areas/domai
 | [e220_radio_profile_mapping_s03](e220_radio_profile_mapping_s03.md) ([#383](https://github.com/AlexanderTsarkov/naviga-app/issues/383)) | E220 mapping. |
 | [tx_power_contract_s03](tx_power_contract_s03.md) ([#384](https://github.com/AlexanderTsarkov/naviga-app/issues/384)) | TX power baseline vs runtime. |
 | [tx_priority_and_arbitration_v0_1](../../nodetable/policy/tx_priority_and_arbitration_v0_1.md) | P0–P3, throttling, expiry. |
+| [packet_context_tx_rules_v0_1](packet_context_tx_rules_v0_1.md) ([#407](https://github.com/AlexanderTsarkov/naviga-app/issues/407)) | Agreed v0.2 packet context and TX rules (Node_Pos_Full, Node_Status). |
 
 ---
 

--- a/docs/product/wip/areas/radio/policy/packet_context_tx_rules_v0_1.md
+++ b/docs/product/wip/areas/radio/policy/packet_context_tx_rules_v0_1.md
@@ -1,0 +1,116 @@
+# Radio — Packet context & TX rules v0.1 (WIP)
+
+**Status:** WIP planning. Consolidated outcome for [#407](https://github.com/AlexanderTsarkov/naviga-app/issues/407) under umbrella [#351](https://github.com/AlexanderTsarkov/naviga-app/issues/351). No implementation, no canon promotion, no protocol number finalization.
+
+**Sources:** `_working/research/packetization_tx_v0_2_proposal_407.md`, `_working/research/tx_rules_from_code_407.md`, `_working/research/packetization_tx_policy_s03_state_407.md`.
+
+---
+
+## 1) Current v0.1 behavior (from code)
+
+What the firmware does today — **baseline**, not the v0.2 target.
+
+| Aspect | Current code behavior |
+|--------|------------------------|
+| **Cadence gate** | Single clock: `elapsed = now_ms - last_tx_ms_`; `last_tx_ms_` updated only when **Core or Alive** is enqueued. All formation uses the same `time_for_min` / `time_for_silence`. No separate timers for Op or Info. |
+| **allow_core** | Set **true** only by app when a position update is committed (SelfUpdatePolicy: DISTANCE, MAX_SILENCE, FIRST_FIX). Consumed (set false) after one formation pass. At most one Core (and one Tail) per position commit. |
+| **Core + Tail** | Tail only enqueued in the same pass as Core, immediately after Core encode. One seq16 for Core, one for Tail; Tail carries `ref_core_seq16` = Core’s seq16. No Tail without Core. |
+| **Op + Info** | Both enqueued when `(time_for_min \|\| time_for_silence)` AND the relevant `has_*` flags. Same gate as Core/Alive. No separate 10 min for Info in code. |
+| **Queue** | Five fixed slots (Core, Alive, Tail1, Tail2, Info). Replace-in-place by slot index. Selection: P0 > P2 > P3; within priority: replaced_count DESC, created_at_ms ASC. Formation runs only when `!send_policy_.has_pending()` (after last payload successfully sent). |
+
+**Explicit TX rule table (current code):**
+
+| Packet | Trigger | Priority | Coalesce | Notes |
+|--------|---------|----------|----------|--------|
+| Core_Pos | pos_valid AND (time_for_min AND allow_core) OR time_for_silence | P0 | One slot | allow_core app-driven. |
+| Alive | !pos_valid AND time_for_silence | P0 | One slot | No allow_core. |
+| Core_Tail | Only when Core_Pos enqueued same pass | P2 | One slot; ref_core_seq16 in payload | No independent trigger. |
+| Operational (0x04) | (time_for_min \|\| time_for_silence) AND (has_battery \|\| has_uptime) | P3 | One slot | Same gate as Core. |
+| Informative (0x05) | (time_for_min \|\| time_for_silence) AND (has_max_silence \|\| has_hw_profile \|\| has_fw_version) | P3 | One slot | Same gate as Core. |
+
+---
+
+## 2) Agreed v0.2 packetization direction (planning target)
+
+- **Position path:** **Node_Pos_Full** = Core position (WHO + WHERE + freshness) + **2-byte Pos_Quality**. One packet, one slot, one seq16 per position update; no ref_core_seq16. Replaces Core_Pos + Core_Tail. **Split Core + Tail** is **not** the default; retained only as a possible **fallback/calibration hypothesis** if needed.
+- **Alive:** Unchanged; no-fix liveness.
+- **Status path:** **Node_Status** = single packet with **full snapshot** of operational + informative fields. One slot; full snapshot on any valid trigger.
+
+**Node_Pos_Full payload (agreed):** Core position (Common + lat/lon) + 2-byte Pos_Quality. Pos_Quality bit layout TBD in encoding contract.
+
+**Node_Status payload (agreed):** Common prefix + batteryPercent, battery_Est_Rem_Time, TX_power_Ch_throttle, uptime10m, role_id, maxSilence10s, hwProfileId, fwVersionId (encoding order and optionality TBD in contract).
+
+**Node_Status TX semantics (agreed):** See **§2a** for the full Node_Status lifecycle policy (bootstrap, triggers, steady-state, timing).
+
+- **Timing (agreed):** `min_status_interval_ms = 30s`; `T_status_max = 300s` (T_status_max = 10 × min_status_interval_ms). If no Node_Status was sent within T_status_max, send a full Node_Status at the next allowed opportunity.
+
+**Explicit TX rule table (agreed v0.2):**
+
+| Packet | Trigger | Earliest_at | Deadline | Coalesce | Priority | Replaceability under load |
+|--------|---------|-------------|----------|----------|----------|----------------------------|
+| Node_Pos_Full | pos_valid AND (min_interval AND allow_core) OR max_silence | last_pos_tx_ms + min_interval_ms | max_silence → force PosFull or Alive | One slot | P0 | Not replaceable by P3. |
+| Alive | !pos_valid AND time_for_silence | — | max_silence | One slot | P0 | Not replaceable by P3. |
+| Node_Status | Any urgent or threshold trigger; subject to earliest_at and T_status_max | last_status_enqueue_ms + min_status_interval_ms | T_status_max (bounded periodic refresh) | One slot; snapshot replace | P3 | Skip/expire first. |
+
+---
+
+### 2a) Node_Status lifecycle policy (agreed)
+
+Applies **only to Node_Status**. Does not change Node_PosFull cadence or creation rules. Node_PosFull and Node_Status remain separate packet types. Node_Status is always sent as a **full snapshot**; no partial Node_Status delivery via other packet types. **Hitchhiking not allowed:** Node_Status is never enqueued in the same formation pass as Node_PosFull; status trigger and send are independent of the position path. No ad hoc piggybacking of status content into Node_PosFull or any other packet type.
+
+**Initial Status Population (bootstrap):**
+
+- On boot/restart set `status_bootstrap_pending = true`.
+- Send one full Node_Status at the first allowed opportunity.
+- Allow one additional bootstrap retry only. **Total bootstrap sends limited to 2.**
+- Second bootstrap send not earlier than `min_status_interval_ms` after the first.
+- Bootstrap then ends; steady-state rules apply.
+
+**Trigger semantics:**
+
+- **Urgent triggers:** TX_power_Ch_throttle, maxSilence10s, role_id (rare config-trigger / urgent-config). Change → eligible to enqueue (replace pending snapshot); send when earliest_at elapsed.
+- **Threshold triggers:** batteryPercent, battery_Est_Rem_Time. Trigger when threshold crossed; also covered by T_status_max.
+- **Hitchhiker-only:** uptime10m, hwProfileId, fwVersionId. Do **not** alone trigger a send; included when Status is sent for urgent/threshold trigger or periodic refresh.
+
+**Steady-state:**
+
+- Any valid trigger raises or updates pending status intent.
+- If status is already pending, further changes **merge into the current pending snapshot**.
+- One logical Node_Status slot/intent only.
+- Node_Status stays standalone. Hitchhiking (same-pass or piggyback with PosFull) is **not allowed**.
+
+**Timing:**
+
+- `min_status_interval_ms = 30s`
+- `T_status_max = 300s` (T_status_max = 10 × min_status_interval_ms)
+- If no Node_Status was sent within T_status_max, send a full Node_Status at the next allowed opportunity.
+
+---
+
+## 3) Migration notes / impact
+
+- **Obsolete with v0.2:** ref_core_seq16 (wire); last_applied_tail_ref_core_seq16 (RX); Core_Tail slot (P2); separate Operational and Informative slots; “MUST NOT send Info on every Operational” as separate rule.
+- **Simpler:** 3 slots (PosFull, Alive, Node_Status); one seq16 per position update; one Status rule set; explicit earliest_at and T_status_max for Status.
+- **New semantics:** Earliest_at / deadline for Status; trigger taxonomy (urgent / threshold / hitchhiker); merge-into-pending snapshot; PosFull wire format.
+
+---
+
+## 4) Open points and external dependencies
+
+- **Pos_Quality 2-byte bit layout:** Encoding contract; tracked as external/dependent work under sibling issue [#359](https://github.com/AlexanderTsarkov/naviga-app/issues/359). Not a blocker for #407 semantic closure.
+
+*Closed / out of scope for #407:* Node_Status lifecycle (including bootstrap and timing) agreed in §2a. Hitchhiking **closed — not allowed**; Node_Status is standalone, independent of PosFull formation pass. Protocol/wire numbering (msg_type, payloadVersion) is a later contract/wire-format follow-up, not part of #407 packet-purpose and TX-rule closure. Backward compatibility is out of scope for this WIP.*
+
+---
+
+## 5) Follow-up WIP alignment (pointer/reference only)
+
+These WIP docs should later be aligned by adding a pointer or short reference to this document and the v0.2 direction; **no removal** of existing v0.1 content until v0.2 is adopted in canon.
+
+- **packet_sets_v0_1.md** ([../nodetable/policy/packet_sets_v0_1.md](../nodetable/policy/packet_sets_v0_1.md)) — add pointer to this doc and v0.2 direction (PosFull + Node_Status).
+- **tx_priority_and_arbitration_v0_1.md** ([../nodetable/policy/tx_priority_and_arbitration_v0_1.md](../nodetable/policy/tx_priority_and_arbitration_v0_1.md)) — when v0.2 is promoted, add section or link for v0.2 (three slots: PosFull, Alive, Node_Status).
+- **channel_utilization_budgeting_and_profile_strategy_s03_v0_1.md** ([channel_utilization_budgeting_and_profile_strategy_s03_v0_1.md](channel_utilization_budgeting_and_profile_strategy_s03_v0_1.md)) — align naming (Node_Status) and split-Core-Tail as fallback hypothesis if needed.
+
+---
+
+This document is the **authoritative WIP reference** for #407 packet context and TX rules. v0.2 is the agreed planning target; it is not yet implemented or canon.


### PR DESCRIPTION
## Summary

- Consolidate #407 WIP planning outcome for packet purpose / contents / creation / send rules.
- Record Node_Status lifecycle policy and explicit “no hitchhiking”.

## Scope

- Authoritative WIP snapshot in `docs/product/wip/areas/radio/policy/packet_context_tx_rules_v0_1.md`.
- Minimal supporting WIP alignment: pointers from packet_sets_v0_1, tx_priority_and_arbitration_v0_1, channel_utilization_budgeting (related/artifact tables only).
- No implementation, no canon, no protocol numbering.

## How to verify

- Read `docs/product/wip/areas/radio/policy/packet_context_tx_rules_v0_1.md`.
- Confirm Node_PosFull / Node_Status semantics are explicit.
- Confirm Node_Status lifecycle values: 30s / 300s.
- Confirm Pos_Quality is external to sibling issue track (#359).
- Confirm hitchhiking is explicitly not allowed.

## Risk / notes

- Docs-only; no behavior change.
- Current code baseline remains documented separately as baseline, not target.

## Docs

- Yes, WIP docs updated.

## Issue link

- Relates to #407 under #351.
- Do not use “Closes #407”; issue remains open until review/merge and any final follow-up status transition is decided.
