### PR TITLE
chore: start S03 execution iteration workspace

### DIFF
--- a/_working/ITERATION.md
+++ b/_working/ITERATION.md
@@ -1,12 +1,16 @@
-S01__2026-02__OOTB.v1_consolidation_cleanup
+S03__2026-03__Execution.v1
 
 Work Area: Implementation (+ Test allowed)
-Tech Area: <comma-separated>
-Scope: <one line>
+Tech Area: Firmware, Protocol, Radio, Persistence, Testing
+Scope: Implement canon slice per #416; start with P0 (#417–#422)
+
 Links:
-- Issue/Epic: <...>
-- PRs: <...>
+- Issue/Epic: #416
+- P0: #417, #418, #419, #420, #421, #422
+- Referenced trackers: #296, #355
+
 Definition of Done:
-- [ ] ...
+- P0 complete + CI green + bench sanity evidence captured
+
 Notes:
-- ...
+- Execution umbrella #416 (not planning #351). Product specs stay in docs/product/** and docs/product/wip/**.

--- a/_working/README.md
+++ b/_working/README.md
@@ -42,10 +42,18 @@ Research outputs for the current iteration go under `_working/research/` (see CL
 
 Other hw_tests subfolders: `2026-02-23_s02_266` (provision/reboot), `2026-02-23_s02_267` (OOTB baseline), `2026-02-23_s02_268` (radio smoke), `2026-02-23_s02_276_tail_proof` (tail proof). See each folder’s `notes.md` for issue links.
 
-## Current iteration (template)
+## Current iteration
 
-- **Iteration ID/Name:** *(read from [ITERATION.md](ITERATION.md); do not invent)*
+- **Iteration ID/Name:** S03__2026-03__Execution.v1 (from [ITERATION.md](ITERATION.md))
 - **Work Area:** Implementation (primary), Test (allowed)
-- **Tech Area(s):** Firmware / Mobile App / Backend / Hardware / Protocol / Architecture
-- **Related Issue(s)/PR(s):** *(optional)*
-- **Goal / DoD / Status:** *(optional)*
+- **Tech Area(s):** Firmware, Protocol, Radio, Persistence, Testing
+- **Execution umbrella:** [#416](https://github.com/AlexanderTsarkov/naviga-app/issues/416) — S03 Execution planning: implement canon slice (code+tests plan)
+- **P0 issues:** #417, #418, #419, #420, #421, #422
+- **Referenced trackers:** #296, #355
+- **Goal / DoD:** Implement canon slice per #416; P0 complete + CI green + bench sanity evidence captured
+
+### How we work in S03 execution
+
+- **Keep here:** logs, bench evidence, investigation notes, and other artifacts that support the current implementation/test iteration.
+- **Product specs stay in** [docs/product/](../docs/product/) and [docs/product/wip/](../docs/product/wip/); do not add WIP product specs to `_working/`.
+- **Execution entry point:** #416 (not the planning umbrella #351). Work branches and PRs should link to #416 and the relevant P0 sub-issue.


### PR DESCRIPTION
**Workspace / housekeeping only.** No firmware, protocol, or runtime changes.

- Updates `_working/ITERATION.md` to S03 execution iteration `S03__2026-03__Execution.v1` and points to execution umbrella **#416** (not planning #351).
- Updates `_working/README.md` current iteration section and adds "How we work in S03 execution" (artifacts here; product specs stay in `docs/product/**`; #416 as execution entry point).
- Removed `_working/.DS_Store` from the tree (already gitignored).

**After merge:** #416 is the execution entry point; P0 work (e.g. #417) can start from a fresh branch off `main`.
