### PR TITLE
refactor(fw): align NodeTable NodeEntry to canon S03 field map (#419)

### DIFF
--- a/firmware/src/domain/node_table.h
+++ b/firmware/src/domain/node_table.h
@@ -8,56 +8,59 @@
 namespace naviga {
 namespace domain {
 
+/** Sentinel for snr_last when radio does not provide SNR (e.g. E22 UART backend). Per link_metrics_v0; not persisted. */
+constexpr int8_t kSnrLastUnsupported = 127;
+
 struct NodeEntry {
+  // --- Core_Pos / Identity (primary key) ---
   uint64_t node_id = 0;
-  uint16_t short_id = 0;
-  bool is_self = false;
-  bool pos_valid = false;
-  bool short_id_collision = false;
-  int32_t lat_e7 = 0;
-  int32_t lon_e7 = 0;
+
+  // --- Core_Pos (position) ---
+  bool   pos_valid = false;
+  int32_t lat_e7   = 0;
+  int32_t lon_e7   = 0;
   uint16_t pos_age_s = 0;
-  int8_t last_rx_rssi = 0;
-  // Global per-node sequence counter: last accepted seq16 from ANY Node_* packet type
-  // (Core, Alive, Tail-1, Tail-2, Info). Used as the (nodeId48, seq16) dedupe key
-  // per rx_semantics_v0 §1. MUST NOT be interpreted as "last Core seq" or "last
-  // position freshness" — those roles belong to last_core_seq16 and pos_age_s.
+
+  // --- Core / Activity (seq16, ref_core_seq16, Tail-1 apply tracking) ---
+  // Global per-node sequence counter: last accepted seq16 from ANY Node_* packet type (Core, Alive, Tail-1, Tail-2, Info).
+  // Dedupe key (nodeId48, seq16) per rx_semantics_v0 §1. Not "last Core seq" — that is last_core_seq16.
   uint16_t last_seq = 0;
-  uint32_t last_seen_ms = 0;
-  bool in_use = false;
+  uint16_t last_core_seq16 = 0;  ///< seq16 of last accepted Node_OOTB_Core_Pos; Tail-1 ref_core_seq16 match key.
+  bool     has_core_seq16  = false;
+  uint16_t last_applied_tail_ref_core_seq16 = 0;  ///< Variant 2: at most one Tail-1 per Core sample.
+  bool     has_applied_tail_ref_core_seq16  = false;
 
-  // Core_Tail binding: seq16 of the last accepted Node_OOTB_Core_Pos for this node.
-  // Compared against ref_core_seq16 from incoming Core_Tail frames to enforce
-  // the CoreRef-lite gate (tail1_packet_encoding_v0 §4.1).
-  uint16_t last_core_seq16 = 0;
-  bool     has_core_seq16  = false;  ///< false until first Core received.
-
-  // Variant 2 invariant: at most one Core_Tail per Core_Pos sample.
-  // Tracks the ref_core_seq16 of the last successfully applied Core_Tail.
-  // If a new Core_Tail arrives with the same ref_core_seq16 (even with a
-  // different seq16), it is treated as an unexpected duplicate and ignored.
-  uint16_t last_applied_tail_ref_core_seq16 = 0;
-  bool     has_applied_tail_ref_core_seq16  = false;  ///< false until first Tail-1 applied.
-
-  // Tail-1 optional fields (position quality for last Core sample).
+  // --- Core_Tail (Tail-1 position quality) ---
   bool    has_pos_flags = false;
   uint8_t pos_flags     = 0x00;
   bool    has_sats      = false;
   uint8_t sats          = 0x00;
 
-  // Node_OOTB_Operational (0x04) fields — dynamic runtime.
-  bool     has_battery       = false;
-  uint8_t  battery_percent   = 0xFF;    ///< 0xFF = not present.
-  bool     has_uptime        = false;
-  uint32_t uptime_sec        = 0xFFFFFFFFu; ///< 0xFFFFFFFF = not present.
+  // --- Operational (Node_OOTB_Operational 0x04) ---
+  bool     has_battery   = false;
+  uint8_t  battery_percent = 0xFF;  ///< 0xFF = not present.
+  bool     has_uptime    = false;
+  uint32_t uptime_sec    = 0xFFFFFFFFu;  ///< 0xFFFFFFFF = not present.
 
-  // Node_OOTB_Informative (0x05) fields — static / user-config.
-  bool     has_max_silence   = false;
-  uint8_t  max_silence_10s   = 0;       ///< 0 = absent/unknown; unit = 10 s.
-  bool     has_hw_profile    = false;
-  uint16_t hw_profile_id     = 0xFFFF;  ///< 0xFFFF = not present.
-  bool     has_fw_version    = false;
-  uint16_t fw_version_id     = 0xFFFF;  ///< 0xFFFF = not present.
+  // --- Informative (Node_OOTB_Informative 0x05) ---
+  bool     has_max_silence = false;
+  uint8_t  max_silence_10s = 0;  ///< unit = 10 s; 0 = absent/unknown.
+  bool     has_hw_profile  = false;
+  uint16_t hw_profile_id   = 0xFFFF;
+  bool     has_fw_version  = false;
+  uint16_t fw_version_id   = 0xFFFF;
+
+  // --- Self / Identity (derived or local) ---
+  uint16_t short_id          = 0;  ///< CRC16-CCITT over node_id LE; display only; not protocol key.
+  bool     is_self           = false;
+  bool     short_id_collision = false;
+
+  // --- Derived / Injected / Debug (receiver-side; link_metrics_v0) ---
+  uint32_t last_seen_ms = 0;   ///< lastRxAt; canon. Exported as lastSeenAgeS at BLE/snapshot export.
+  int8_t   last_rx_rssi = 0;   ///< rssiLast; updated on any accepted RX.
+  int8_t   snr_last     = kSnrLastUnsupported;  ///< snrLast; E22 UNSUPPORTED → NA sentinel until producer wired.
+  uint8_t  last_payload_version_seen = 0xFF;   ///< Debug/injected only; not persisted. 0xFF = not set.
+  bool     in_use       = false;  ///< Internal slot occupancy; not in BLE/snapshot.
 };
 
 class NodeTable {

--- a/firmware/src/domain/nodetable_snapshot.cpp
+++ b/firmware/src/domain/nodetable_snapshot.cpp
@@ -104,13 +104,15 @@ void unpack_record(const uint8_t* in, NodeEntry* e) {
   e->fw_version_id = get_u16_le(in + 35);
   // No persisted presence anchor (canon: last_seen_ms is uptime, not reboot-safe)
   e->last_seen_ms = 0;
-  // Derived / prohibited: not persisted
+  // Derived / injected / debug: not persisted (#418 narrow subset)
   e->is_self = false;
   e->short_id_collision = false;
   e->last_rx_rssi = 0;
   e->last_seq = 0;
   e->last_applied_tail_ref_core_seq16 = 0;
   e->has_applied_tail_ref_core_seq16 = false;
+  e->snr_last = kSnrLastUnsupported;
+  e->last_payload_version_seen = 0xFF;
   e->in_use = true;
 }
 

--- a/firmware/test/test_node_table_domain/test_node_table_domain.cpp
+++ b/firmware/test/test_node_table_domain/test_node_table_domain.cpp
@@ -10,6 +10,7 @@
 
 using naviga::domain::NodeTable;
 using naviga::domain::NodeEntry;
+using naviga::domain::kSnrLastUnsupported;
 using naviga::domain::build_nodetable_snapshot;
 using naviga::domain::restore_from_nodetable_snapshot;
 
@@ -386,7 +387,7 @@ void test_nodetable_snapshot_restore_is_self_derived() {
   TEST_ASSERT_EQUAL_UINT32(0, e_remote.last_seen_ms);
 }
 
-// #418: excluded fields (last_seq, last_rx_rssi, last_applied_tail_ref) are not persisted; restore sets them 0.
+// #418: excluded fields (last_seq, last_rx_rssi, last_applied_tail_ref, snr_last, last_payload_version_seen) are not persisted; restore sets them to defaults.
 void test_nodetable_snapshot_excluded_fields_not_authoritative() {
   NodeTable table;
   table.set_expected_interval_s(18);
@@ -405,6 +406,8 @@ void test_nodetable_snapshot_excluded_fields_not_authoritative() {
     TEST_ASSERT_EQUAL(0, entries[i].last_seq);
     TEST_ASSERT_EQUAL(0, entries[i].last_rx_rssi);
     TEST_ASSERT_FALSE(entries[i].has_applied_tail_ref_core_seq16);
+    TEST_ASSERT_EQUAL(kSnrLastUnsupported, entries[i].snr_last);  // #419: not persisted; restore uses sentinel
+    TEST_ASSERT_EQUAL(0xFF, entries[i].last_payload_version_seen);  // debug-only; not persisted
   }
 }
 
@@ -422,6 +425,24 @@ void test_nodetable_snapshot_old_version_rejected() {
   uint8_t v1_header[] = { 'N', 'T', 1, 0, 0 };  // magic + version 1 + count 0
   const size_t n = restore_from_nodetable_snapshot(v1_header, sizeof(v1_header), 1, entries, NodeTable::kMaxNodes);
   TEST_ASSERT_EQUAL(0, n);
+}
+
+// #419: S03 structural alignment — new entries have snr_last sentinel and last_payload_version_seen unset.
+void test_nodetable_s03_snr_last_and_debug_defaults() {
+  NodeTable table;
+  table.set_expected_interval_s(10);
+  const uint64_t self_id = 0x1111111111111111ULL;
+  const uint64_t remote_id = 0x2222222222222222ULL;
+  table.init_self(self_id, 1000);
+  table.upsert_remote(remote_id, true, 0, 0, 0, -50, 10, 2000);
+
+  NodeEntry e_self{}, e_remote{};
+  TEST_ASSERT_TRUE(table.find_entry_for_test(self_id, &e_self));
+  TEST_ASSERT_TRUE(table.find_entry_for_test(remote_id, &e_remote));
+  TEST_ASSERT_EQUAL(kSnrLastUnsupported, e_self.snr_last);
+  TEST_ASSERT_EQUAL(kSnrLastUnsupported, e_remote.snr_last);
+  TEST_ASSERT_EQUAL(0xFF, e_self.last_payload_version_seen);
+  TEST_ASSERT_EQUAL(0xFF, e_remote.last_payload_version_seen);
 }
 
 // #418: dirty flag set after mutation, clear_dirty clears.
@@ -459,6 +480,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_nodetable_snapshot_excluded_fields_not_authoritative);
   RUN_TEST(test_nodetable_snapshot_corrupt_returns_zero);
   RUN_TEST(test_nodetable_snapshot_old_version_rejected);
+  RUN_TEST(test_nodetable_s03_snr_last_and_debug_defaults);
   RUN_TEST(test_nodetable_dirty_cleared_after_clear);
   return UNITY_END();
 }


### PR DESCRIPTION
Closes #419. Umbrella: #416.

## Dependency
- Builds on #418 / PR #429 (NodeTable persistence snapshot + restore). Persisted subset remains narrow; no new fields added to snapshot format.

## Summary
Structural alignment of `NodeEntry` to the canon S03 field map / master table. No RX apply/coalesce semantics change (#421); no TX/BLE/stub fields.

### 1. Final NodeEntry field grouping (by canon categories)
- **Core_Pos / Identity:** `node_id`
- **Core_Pos (position):** `pos_valid`, `lat_e7`, `lon_e7`, `pos_age_s`
- **Core / Activity:** `last_seq`, `last_core_seq16`, `has_core_seq16`, `last_applied_tail_ref_core_seq16`, `has_applied_tail_ref_core_seq16`
- **Core_Tail:** `has_pos_flags`, `pos_flags`, `has_sats`, `sats`
- **Operational:** `has_battery`, `battery_percent`, `has_uptime`, `uptime_sec`
- **Informative:** `has_max_silence`, `max_silence_10s`, `has_hw_profile`, `hw_profile_id`, `has_fw_version`, `fw_version_id`
- **Self / Identity:** `short_id`, `is_self`, `short_id_collision`
- **Derived / Injected / Debug:** `last_seen_ms`, `last_rx_rssi`, `snr_last`, `last_payload_version_seen`, `in_use`

### 2. Canon fields added
- **`snr_last`** (snrLast): S03 required; `int8_t`, default `kSnrLastUnsupported` (127) for E22/unsupported path until producer wiring in #421.
- **`last_payload_version_seen`**: Implemented as **debug-only injected** field; not persisted. `0xFF` = not set.

### 3. Intentionally not implemented (this PR)
- activityState, aliveStatus, networkName/localAlias, tier/pin, txPowerStep, node_name (#368), extra telemetry, eviction redesign.

### 4. Placeholder / stub removal
- None. No misleading stand-ins removed; only reorder + two new fields.

### 5. Tests
- `test_nodetable_s03_snr_last_and_debug_defaults`: new entries have `snr_last == kSnrLastUnsupported`, `last_payload_version_seen == 0xFF`.
- `test_nodetable_snapshot_excluded_fields_not_authoritative`: extended to assert restored entries get `snr_last` and `last_payload_version_seen` set to defaults (not persisted).

### Quality
- CI: `pio test -e test_native` and firmware build (`devkit_e220_oled_gnss`) verified.
- #418 snapshot policy unchanged; 37-byte record and unpack logic unchanged except setting the two new fields to defaults on restore.

Made with [Cursor](https://cursor.com)