### PR TITLE
docs(#421): RX semantics v0.1 canon alignment

### DIFF
--- a/docs/product/areas/nodetable/policy/rx_semantics_v0.md
+++ b/docs/product/areas/nodetable/policy/rx_semantics_v0.md
@@ -87,8 +87,9 @@ The following strategies may be adopted in a future iteration; they are **out of
 
 ---
 
-## 6) Related
+## 6) Implementation and related
 
+- **Implementation (#421):** `firmware/src/domain/node_table.cpp` — `upsert_remote` (Core_Pos/Alive), `apply_tail1`, `apply_tail2`, `apply_info`. Tail–Core ref fields are runtime-local decoder state only (not BLE, not persisted); see [nodetable_master_field_table_v0.md](nodetable_master_field_table_v0.md) §7.
 - **Beacon encoding:** [beacon_payload_encoding_v0](../contract/beacon_payload_encoding_v0.md) — Core/Tail layouts; §3.1 position-bearing vs alive-bearing.
 - **Alive encoding:** [alive_packet_encoding_v0](../contract/alive_packet_encoding_v0.md).
 - **Field cadence:** [field_cadence_v0](field_cadence_v0.md) — Core only with valid fix; maxSilence via Alive when no fix.

--- a/firmware/src/domain/node_table.cpp
+++ b/firmware/src/domain/node_table.cpp
@@ -162,6 +162,17 @@ void NodeTable::touch_self(uint32_t now_ms) {
   set_dirty();
 }
 
+// ── RX/apply semantics (#421: canon rx_semantics_v0, packet_to_nodetable_mapping_v0) ─
+//
+// upsert_remote (Core_Pos / Alive) and apply_tail1 / apply_tail2 / apply_info implement
+// accepted vs duplicate vs out-of-order per rx_semantics_v0 §1 (seq16 wrap rule).
+// - Newer: apply payload; update last_seen_ms, last_rx_rssi, last_seq; Core path updates
+//   last_core_seq16/has_core_seq16 for Tail-1 ref gate only (runtime-local, not BLE/persisted).
+// - Same/Older: refresh last_seen_ms and last_rx_rssi only; MUST NOT overwrite position/telemetry.
+// Tail–Core correlation uses last_core_seq16 and last_applied_tail_ref_core_seq16 as
+// runtime-local decoder state only (nodetable_master_field_table_v0 §7); not canonical
+// NodeTable product truth; not exported to BLE; not persisted.
+
 bool NodeTable::upsert_remote(uint64_t node_id,
                               bool pos_valid,
                               int32_t lat_e7,
@@ -242,6 +253,8 @@ bool NodeTable::upsert_remote(uint64_t node_id,
   return true;
 }
 
+// apply_tail1: ref_core_seq16 must match last_core_seq16 (runtime-local); at most one Tail
+// per Core sample. Applies only pos_flags/sats; MUST NOT touch position (rx_semantics_v0 §4).
 bool NodeTable::apply_tail1(uint64_t node_id,
                             uint16_t seq16,
                             uint16_t ref_core_seq16,


### PR DESCRIPTION
# RX semantics v0.1 canon alignment (#421)

## Summary
Makes RX/apply semantics **explicit** in code and docs: comments and policy reference state that behavior mirrors rx_semantics_v0 and packet_to_nodetable_mapping_v0. **No behavior change** — implementation already matched canon; this is documentation/truth-lock only.

**Umbrella:** #416. **Boundary:** #422 = packetization / v0.2 (no change in this PR).

## Changes
- **node_table.cpp** — Comment block above `upsert_remote`: RX/apply semantics follow rx_semantics_v0 and packet_to_nodetable_mapping_v0 (Newer vs Same/Older; no overwrite of position/telemetry). **Legacy ref fields** (last_core_seq16, last_applied_tail_ref_core_seq16) are **runtime-local decoder state only** — not BLE, not persisted (nodetable_master_field_table_v0 §7). Short comment above `apply_tail1`: ref match and one-per-ref; MUST NOT touch position (rx_semantics_v0 §4).
- **rx_semantics_v0.md** — §6 Implementation: implementation lives in node_table.cpp (upsert_remote, apply_tail1, apply_tail2, apply_info); ref fields runtime-local per master table §7.

## Validation
- **`pio run -e devkit_e220_oled`** — PASSED.
- **Tests:** No new tests added. Existing tests (test_beacon_logic apply_tail1, test_node_table_domain seq/ooo and restore exclusions) are relied upon; no claim of new coverage or new green suites beyond what was already in place.

## Boundary
- #422 (packetization / v0.2): no change. RX/apply remains v0.1.

Closes #421.
