### PR TITLE
feat(#438): remove v0.1 RX compatibility and finalize v0.2-only cutover

### DIFF
--- a/docs/product/areas/nodetable/policy/packet_migration_v01_v02.md
+++ b/docs/product/areas/nodetable/policy/packet_migration_v01_v02.md
@@ -4,7 +4,7 @@
 **Issue:** [#435](https://github.com/AlexanderTsarkov/naviga-app/issues/435).  
 **Companion:** [packet_truth_table_v02](packet_truth_table_v02.md) — canonical v0.2 packet family and semantics.
 
-This memo states the **explicit compatibility policy** for the transition from v0.1 to v0.2 packet family. Implementation must follow this policy; removal of v0.1 acceptance is a later cleanup PR.
+This memo states the **explicit compatibility policy** for the transition from v0.1 to v0.2 packet family. **Cutover complete (#438):** RX is v0.2-only; v0.1 packets are dropped.
 
 ---
 
@@ -15,27 +15,22 @@ This memo states the **explicit compatibility policy** for the transition from v
 
 ---
 
-## 2) What we accept (RX) during transition
+## 2) What we accept (RX) — post-cutover (#438)
 
-- **Transition phase:** RX **accepts** both:
-  - **v0.2:** Node_Pos_Full, Node_Status, Alive.
-  - **v0.1:** Core_Pos, Core_Tail, Node_Operational, Node_Informative.
-- All accepted packets apply to the **same** NodeTable normalized fields. Compatibility logic (recognizing v0.1 `msg_type`s and v0.2 `msg_type`s or payloadVersion) lives in the RX decode/dispatch layer, **clearly scoped** (e.g. one compatibility module or flag) and documented as temporary.
+- **RX accepts v0.2 only:** Node_Pos_Full (0x06), Node_Status (0x07), Alive (0x02).
+- **v0.1 packets (0x01, 0x03, 0x04, 0x05) are rejected** at decode_header; frames are dropped. No compatibility path remains.
 
 ---
 
-## 3) v0.1 is compatibility-only
+## 3) v0.1 is obsolete on RX
 
-- v0.1 packet types are **not** canon during and after transition. They are accepted only for **backward compatibility** so that new firmware can still read old nodes (and vice versa during rollout).
-- Canonical packet family is v0.2 only; see [packet_truth_table_v02](packet_truth_table_v02.md).
+- v0.1 packet types are **not** accepted. Canonical packet family is v0.2 only; see [packet_truth_table_v02](packet_truth_table_v02.md).
 
 ---
 
-## 4) Cutover expectation
+## 4) Cutover complete
 
-- **Duration / criterion:** Transition lasts until **fleet or config cutover** or **N releases** (to be decided at cutover time).
-- **Post-cutover:** RX may **accept v0.2 only**; v0.1 packets optionally **log and drop**. A version flag or config can turn off “v0.1 accept” when cutover is decided.
-- **Cleanup PR (later):** Remove v0.1 accept path and last_applied_tail_ref_core_seq16 from product surface; update seq/ref policy docs to v0.2-only.
+- **#438:** v0.1 accept path removed; decode_header and BeaconLogic on_rx accept only 0x02, 0x06, 0x07. last_applied_tail_ref_core_seq16 removed from NodeTable.
 
 ---
 
@@ -43,8 +38,7 @@ This memo states the **explicit compatibility policy** for the transition from v
 
 | Phase | TX (what we send) | RX (what we accept) |
 |-------|-------------------|----------------------|
-| **Transition** | v0.2 only (Node_Pos_Full, Node_Status, Alive) | v0.2 **and** v0.1 (Core_Pos, Core_Tail, Operational, Informative) |
-| **Post-cutover** | v0.2 only | v0.2 only; v0.1 optionally log & drop |
+| **Post-cutover** | v0.2 only (Node_Pos_Full, Node_Status, Alive) | v0.2 only; v0.1 dropped |
 
 ---
 

--- a/docs/product/areas/nodetable/policy/packet_sets_v0.md
+++ b/docs/product/areas/nodetable/policy/packet_sets_v0.md
@@ -95,7 +95,7 @@ Firmware matches this policy: **Core_Pos** and **Alive** use P0; **Node_Core_Tai
 The **canonical v0.2** packet set and truth table are defined in:
 
 - **[packet_truth_table_v02.md](packet_truth_table_v02.md)** ([#435](https://github.com/AlexanderTsarkov/naviga-app/issues/435)) — v0.2 packet family (Node_Pos_Full, Node_Status, Alive), field composition, TX/RX semantics, airtime.
-- **[packet_migration_v01_v02.md](packet_migration_v01_v02.md)** — Compatibility policy: TX v0.2 only; RX accepts v0.1 + v0.2 during transition; cutover expectation.
+- **[packet_migration_v01_v02.md](packet_migration_v01_v02.md)** — Compatibility policy: TX and RX v0.2 only; cutover complete (#438).
 
 This document (§1–§5) describes **v0.1** packet sets. For v0.2 canon and migration, use the links above.
 

--- a/firmware/protocol/packet_header.h
+++ b/firmware/protocol/packet_header.h
@@ -35,16 +35,16 @@ constexpr size_t kMaxFrameSize = kHeaderSize + kMaxPayloadLen;
 
 /** msg_type registry v0 (ootb_radio_v0.md §3.2) + v0.2 (#435).
  *
- * v0.1 (compatibility-only during transition): 0x01–0x05.
- * v0.2 canonical TX: BeaconPosFull (0x06), BeaconStatus (0x07), BeaconAlive (0x02).
+ * v0.2 canonical (#438): RX accepts only 0x02 (BeaconAlive), 0x06 (BeaconPosFull), 0x07 (BeaconStatus).
+ * v0.1 types 0x01, 0x03, 0x04, 0x05 are no longer accepted on RX (log and drop).
  */
 enum class MsgType : uint8_t {
   Reserved     = 0x00,  ///< MUST NOT be used; drop on receive.
-  BeaconCore   = 0x01,  ///< Node_OOTB_Core_Pos (v0.1 compat); 15 B payload.
-  BeaconAlive  = 0x02,  ///< Node_OOTB_I_Am_Alive; 9–10 B payload; v0.2 retained.
-  BeaconTail1  = 0x03,  ///< Node_OOTB_Core_Tail (v0.1 compat); 11 B min payload.
-  BeaconTail2  = 0x04,  ///< Node_OOTB_Operational (v0.1 compat); 9 B min payload.
-  BeaconInfo   = 0x05,  ///< Node_OOTB_Informative (v0.1 compat); 9 B min payload.
+  BeaconCore   = 0x01,  ///< Node_OOTB_Core_Pos (v0.1); no longer accepted on RX (#438).
+  BeaconAlive  = 0x02,  ///< Node_OOTB_I_Am_Alive; 9–10 B payload; v0.2.
+  BeaconTail1  = 0x03,  ///< Node_OOTB_Core_Tail (v0.1); no longer accepted on RX (#438).
+  BeaconTail2  = 0x04,  ///< Node_OOTB_Operational (v0.1); no longer accepted on RX (#438).
+  BeaconInfo   = 0x05,  ///< Node_OOTB_Informative (v0.1); no longer accepted on RX (#438).
   BeaconPosFull = 0x06,  ///< v0.2 Node_Pos_Full; 17 B payload (#435).
   BeaconStatus  = 0x07,  ///< v0.2 Node_Status; 19 B payload (#435).
 };
@@ -84,11 +84,11 @@ inline bool encode_header(const PacketHeader& hdr, uint8_t* out, size_t out_cap)
 /**
  * Decode the first 2 bytes of \a in into \a hdr.
  *
- * Validates msg_type: returns false if msg_type is Reserved (0x00) or
- * outside the known registry (> BeaconInfo). reserved bits are stored
- * as-is (non-zero reserved is accepted per forward-compat rule).
+ * v0.2-only RX (#438): accepts only 0x02 (BeaconAlive), 0x06 (BeaconPosFull), 0x07 (BeaconStatus).
+ * Returns false for Reserved (0x00), v0.1 types (0x01, 0x03, 0x04, 0x05), or unknown (> 0x07).
+ * reserved bits are stored as-is (non-zero reserved accepted per forward-compat rule).
  *
- * @return true if msg_type is known and non-reserved; false otherwise.
+ * @return true if msg_type is accepted for RX; false otherwise.
  */
 inline bool decode_header(const uint8_t* in, size_t in_size, PacketHeader* hdr) {
   if (!in || !hdr || in_size < kHeaderSize) {
@@ -102,6 +102,13 @@ inline bool decode_header(const uint8_t* in, size_t in_size, PacketHeader* hdr) 
 
   if (mt == static_cast<uint8_t>(MsgType::Reserved) ||
       mt > static_cast<uint8_t>(MsgType::BeaconStatus)) {
+    return false;
+  }
+  // v0.2-only: reject v0.1 packet types (0x01 Core, 0x03 Tail1, 0x04 Tail2, 0x05 Info).
+  if (mt == static_cast<uint8_t>(MsgType::BeaconCore) ||
+      mt == static_cast<uint8_t>(MsgType::BeaconTail1) ||
+      mt == static_cast<uint8_t>(MsgType::BeaconTail2) ||
+      mt == static_cast<uint8_t>(MsgType::BeaconInfo)) {
     return false;
   }
   hdr->msg_type    = static_cast<MsgType>(mt);

--- a/firmware/src/domain/beacon_logic.cpp
+++ b/firmware/src/domain/beacon_logic.cpp
@@ -352,31 +352,6 @@ bool BeaconLogic::on_rx(uint32_t now_ms,
   const uint8_t* payload     = frame + protocol::kHeaderSize;
   const size_t   payload_len = len - protocol::kHeaderSize;
 
-  if (hdr.msg_type == protocol::MsgType::BeaconCore) {
-    protocol::GeoBeaconFields fields{};
-    const protocol::DecodeError err =
-        protocol::decode_geo_beacon(protocol::ConstByteSpan{payload, payload_len}, &fields);
-    if (err != protocol::DecodeError::Ok) {
-      return false;
-    }
-    if (out_node_id)  { *out_node_id  = fields.node_id; }
-    if (out_seq)      { *out_seq      = fields.seq; }
-    if (out_pos_valid){ *out_pos_valid = (fields.pos_valid != 0); }
-    if (out_type)     { *out_type     = PacketLogType::CORE; }
-    if (out_core_seq) { *out_core_seq = 0; }
-
-    const int32_t lat_e7 = static_cast<int32_t>(std::llround(fields.lat_deg * 1e7));
-    const int32_t lon_e7 = static_cast<int32_t>(std::llround(fields.lon_deg * 1e7));
-    return table.upsert_remote(fields.node_id,
-                               true,
-                               lat_e7,
-                               lon_e7,
-                               0,  // pos_age_s not in BeaconCore v0
-                               rssi_dbm,
-                               fields.seq,
-                               now_ms);
-  }
-
   if (hdr.msg_type == protocol::MsgType::BeaconAlive) {
     protocol::AliveFields alive{};
     const protocol::AliveDecodeError err =
@@ -399,76 +374,6 @@ bool BeaconLogic::on_rx(uint32_t now_ms,
                                rssi_dbm,
                                alive.seq,
                                now_ms);
-  }
-
-  if (hdr.msg_type == protocol::MsgType::BeaconTail1) {
-    protocol::Tail1Fields tail1{};
-    const protocol::Tail1DecodeError err =
-        protocol::decode_tail1_payload(payload, payload_len, &tail1);
-    if (err != protocol::Tail1DecodeError::Ok) {
-      return false;
-    }
-    if (out_node_id)  { *out_node_id  = tail1.node_id; }
-    if (out_seq)      { *out_seq      = tail1.seq16; }
-    if (out_pos_valid){ *out_pos_valid = false; }
-    if (out_type)     { *out_type     = PacketLogType::TAIL1; }
-    if (out_core_seq) { *out_core_seq = tail1.ref_core_seq16; }
-
-    // Apply Tail-1: ref_core_seq16 match enforced inside apply_tail1.
-    // seq16 is the packet's own global counter; ref_core_seq16 is the Core linkage key.
-    // Return value indicates match (true) or silent drop (false).
-    // Either way we return true to the caller — the frame was valid.
-    table.apply_tail1(tail1.node_id,
-                      tail1.seq16,
-                      tail1.ref_core_seq16,
-                      tail1.has_pos_flags, tail1.pos_flags,
-                      tail1.has_sats, tail1.sats,
-                      rssi_dbm,
-                      now_ms);
-    return true;
-  }
-
-  if (hdr.msg_type == protocol::MsgType::BeaconTail2) {
-    protocol::Tail2Fields tail2{};
-    const protocol::Tail2DecodeError err =
-        protocol::decode_tail2_payload(payload, payload_len, &tail2);
-    if (err != protocol::Tail2DecodeError::Ok) {
-      return false;
-    }
-    if (out_node_id)  { *out_node_id  = tail2.node_id; }
-    if (out_seq)      { *out_seq      = tail2.seq16; }
-    if (out_pos_valid){ *out_pos_valid = false; }
-    if (out_type)     { *out_type     = PacketLogType::TAIL2; }
-    if (out_core_seq) { *out_core_seq = 0; }
-
-    return table.apply_tail2(tail2.node_id,
-                             tail2.seq16,
-                             tail2.has_battery,  tail2.battery_percent,
-                             tail2.has_uptime,   tail2.uptime_sec,
-                             rssi_dbm,
-                             now_ms);
-  }
-
-  if (hdr.msg_type == protocol::MsgType::BeaconInfo) {
-    protocol::InfoFields info{};
-    const protocol::InfoDecodeError err =
-        protocol::decode_info_payload(payload, payload_len, &info);
-    if (err != protocol::InfoDecodeError::Ok) {
-      return false;
-    }
-    if (out_node_id)  { *out_node_id  = info.node_id; }
-    if (out_seq)      { *out_seq      = info.seq16; }
-    if (out_pos_valid){ *out_pos_valid = false; }
-    if (out_type)     { *out_type     = PacketLogType::INFO; }
-    if (out_core_seq) { *out_core_seq = 0; }
-
-    return table.apply_info(info.node_id,
-                            info.seq16,
-                            info.has_max_silence, info.max_silence_10s,
-                            info.has_hw_profile,  info.hw_profile_id,
-                            info.has_fw_version,  info.fw_version_id,
-                            rssi_dbm,
-                            now_ms);
   }
 
   // v0.2 Node_Pos_Full (0x06) — single-packet position + Pos_Quality (#435).

--- a/firmware/src/domain/beacon_logic.h
+++ b/firmware/src/domain/beacon_logic.h
@@ -6,9 +6,6 @@
 #include "domain/node_table.h"
 #include "../../protocol/geo_beacon_codec.h"
 #include "../../protocol/alive_codec.h"
-#include "../../protocol/tail1_codec.h"
-#include "../../protocol/tail2_codec.h"
-#include "../../protocol/info_codec.h"
 #include "../../protocol/packet_header.h"
 
 namespace naviga {

--- a/firmware/src/domain/node_table.cpp
+++ b/firmware/src/domain/node_table.cpp
@@ -162,16 +162,11 @@ void NodeTable::touch_self(uint32_t now_ms) {
   set_dirty();
 }
 
-// ── RX/apply semantics (#421: canon rx_semantics_v0, packet_to_nodetable_mapping_v0) ─
+// ── RX/apply semantics (#421: canon rx_semantics_v0; #438: v0.2-only, no Tail) ─
 //
-// upsert_remote (Core_Pos / Alive) and apply_tail1 / apply_tail2 / apply_info implement
+// upsert_remote (Alive path) and apply_pos_full / apply_status implement
 // accepted vs duplicate vs out-of-order per rx_semantics_v0 §1 (seq16 wrap rule).
-// - Newer: apply payload; update last_seen_ms, last_rx_rssi, last_seq; Core path updates
-//   last_core_seq16/has_core_seq16 for Tail-1 ref gate only (runtime-local, not BLE/persisted).
-// - Same/Older: refresh last_seen_ms and last_rx_rssi only; MUST NOT overwrite position/telemetry.
-// Tail–Core correlation uses last_core_seq16 and last_applied_tail_ref_core_seq16 as
-// runtime-local decoder state only (nodetable_master_field_table_v0 §7); not canonical
-// NodeTable product truth; not exported to BLE; not persisted.
+// last_core_seq16/has_core_seq16 set by apply_pos_full only (runtime-local, not BLE/persisted).
 
 bool NodeTable::upsert_remote(uint64_t node_id,
                               bool pos_valid,
@@ -188,19 +183,19 @@ bool NodeTable::upsert_remote(uint64_t node_id,
       const Seq16Order order = seq16_order(last_seq, entry.last_seq);
       switch (order) {
         case Seq16Order::Newer:
-          /* Accepted packet: full update (position/telemetry + lastRxAt + link metrics). */
-          entry.pos_valid = pos_valid;
-          entry.lat_e7 = pos_valid ? lat_e7 : 0;
-          entry.lon_e7 = pos_valid ? lon_e7 : 0;
-          entry.pos_age_s = pos_valid ? pos_age_s : 0;
+          /* Accepted packet: update lastRxAt + link metrics; position only when pos_valid (v0.2: Alive does not overwrite position). */
           entry.last_rx_rssi = last_rx_rssi;
           entry.last_seq = last_seq;
           entry.last_seen_ms = now_ms;
-          // Track last Core seq16 for Tail-1 match check (only when pos_valid = Core packet).
           if (pos_valid) {
+            entry.pos_valid = true;
+            entry.lat_e7 = lat_e7;
+            entry.lon_e7 = lon_e7;
+            entry.pos_age_s = pos_age_s;
             entry.last_core_seq16 = last_seq;
             entry.has_core_seq16  = true;
           }
+          /* else: Alive path — do not overwrite position (packet_truth_table_v02). */
           break;
         case Seq16Order::Same:
           /* Duplicate: refresh lastRxAt and link metrics only; MUST NOT overwrite position/telemetry. */
@@ -249,191 +244,6 @@ bool NodeTable::upsert_remote(uint64_t node_id,
   }
   size_++;
   recompute_collisions();
-  set_dirty();
-  return true;
-}
-
-// apply_tail1: ref_core_seq16 must match last_core_seq16 (runtime-local); at most one Tail
-// per Core sample. Applies only pos_flags/sats; MUST NOT touch position (rx_semantics_v0 §4).
-bool NodeTable::apply_tail1(uint64_t node_id,
-                            uint16_t seq16,
-                            uint16_t ref_core_seq16,
-                            bool has_pos_flags, uint8_t pos_flags,
-                            bool has_sats, uint8_t sats,
-                            int8_t rssi_dbm,
-                            uint32_t now_ms) {
-  const int idx = find_entry_index(node_id);
-  if (idx < 0) {
-    // No prior Core for this node — drop silently.
-    return false;
-  }
-  NodeEntry& entry = entries_[static_cast<size_t>(idx)];
-
-  // Dedupe by (nodeId48, seq16): same or older seq16 → refresh link metrics only.
-  const Seq16Order order = seq16_order(seq16, entry.last_seq);
-  if (order == Seq16Order::Same || order == Seq16Order::Older) {
-    entry.last_seen_ms = now_ms;
-    entry.last_rx_rssi = rssi_dbm;
-    return false;
-  }
-
-  if (!entry.has_core_seq16 || entry.last_core_seq16 != ref_core_seq16) {
-    // ref_core_seq16 mismatch (stale, reordered, or no Core yet) — drop silently.
-    // Still update link metrics per tail1_packet_encoding_v0 §4.4.
-    entry.last_seen_ms = now_ms;
-    entry.last_rx_rssi = rssi_dbm;
-    return false;
-  }
-
-  // Variant 2 invariant: at most one Core_Tail per Core_Pos sample.
-  // If a Tail-1 for this ref_core_seq16 has already been applied (even with a
-  // different seq16), treat this as an unexpected duplicate and drop.
-  if (entry.has_applied_tail_ref_core_seq16 &&
-      entry.last_applied_tail_ref_core_seq16 == ref_core_seq16) {
-    entry.last_seen_ms = now_ms;
-    entry.last_rx_rssi = rssi_dbm;
-    return false;
-  }
-
-  // Match: apply Tail-1 fields. MUST NOT touch position.
-  entry.last_seq = seq16;
-  entry.last_applied_tail_ref_core_seq16 = ref_core_seq16;
-  entry.has_applied_tail_ref_core_seq16  = true;
-  if (has_pos_flags) {
-    entry.has_pos_flags = true;
-    entry.pos_flags     = pos_flags;
-  }
-  if (has_sats) {
-    entry.has_sats = true;
-    entry.sats     = sats;
-  }
-  entry.last_seen_ms = now_ms;
-  entry.last_rx_rssi = rssi_dbm;
-  set_dirty();
-  return true;
-}
-
-bool NodeTable::apply_tail2(uint64_t node_id,
-                            uint16_t seq16,
-                            bool has_battery, uint8_t battery_percent,
-                            bool has_uptime, uint32_t uptime_sec,
-                            int8_t rssi_dbm,
-                            uint32_t now_ms) {
-  int idx = find_entry_index(node_id);
-  if (idx < 0) {
-    // Unknown node: create entry (Operational may arrive before Core).
-    int free_idx = find_free_index();
-    if (free_idx < 0) {
-      if (!evict_oldest_grey(now_ms)) {
-        return false;
-      }
-      free_idx = find_free_index();
-      if (free_idx < 0) {
-        return false;
-      }
-    }
-    NodeEntry& new_entry = entries_[static_cast<size_t>(free_idx)];
-    new_entry = NodeEntry{};
-    new_entry.node_id      = node_id;
-    new_entry.short_id     = compute_short_id(node_id);
-    new_entry.is_self      = false;
-    new_entry.in_use       = true;
-    new_entry.last_seen_ms = now_ms;
-    new_entry.last_rx_rssi = rssi_dbm;
-    size_++;
-    recompute_collisions();
-    set_dirty();
-    idx = free_idx;
-  }
-
-  NodeEntry& entry = entries_[static_cast<size_t>(idx)];
-
-  // Dedupe by (nodeId48, seq16): same or older seq16 → refresh link metrics only.
-  const Seq16Order order = seq16_order(seq16, entry.last_seq);
-  if (order == Seq16Order::Same || order == Seq16Order::Older) {
-    entry.last_seen_ms = now_ms;
-    entry.last_rx_rssi = rssi_dbm;
-    set_dirty();
-    return true;
-  }
-
-  // Accepted: apply Operational fields. MUST NOT touch position.
-  entry.last_seq = seq16;
-  if (has_battery) {
-    entry.has_battery     = true;
-    entry.battery_percent = battery_percent;
-  }
-  if (has_uptime) {
-    entry.has_uptime = true;
-    entry.uptime_sec = uptime_sec;
-  }
-  entry.last_seen_ms = now_ms;
-  entry.last_rx_rssi = rssi_dbm;
-  set_dirty();
-  return true;
-}
-
-bool NodeTable::apply_info(uint64_t node_id,
-                           uint16_t seq16,
-                           bool has_max_silence, uint8_t max_silence_10s,
-                           bool has_hw_profile, uint16_t hw_profile_id,
-                           bool has_fw_version, uint16_t fw_version_id,
-                           int8_t rssi_dbm,
-                           uint32_t now_ms) {
-  int idx = find_entry_index(node_id);
-  if (idx < 0) {
-    // Unknown node: create entry (Informative may arrive before Core).
-    int free_idx = find_free_index();
-    if (free_idx < 0) {
-      if (!evict_oldest_grey(now_ms)) {
-        return false;
-      }
-      free_idx = find_free_index();
-      if (free_idx < 0) {
-        return false;
-      }
-    }
-    NodeEntry& new_entry = entries_[static_cast<size_t>(free_idx)];
-    new_entry = NodeEntry{};
-    new_entry.node_id      = node_id;
-    new_entry.short_id     = compute_short_id(node_id);
-    new_entry.is_self      = false;
-    new_entry.in_use       = true;
-    new_entry.last_seen_ms = now_ms;
-    new_entry.last_rx_rssi = rssi_dbm;
-    size_++;
-    recompute_collisions();
-    set_dirty();
-    idx = free_idx;
-  }
-
-  NodeEntry& entry = entries_[static_cast<size_t>(idx)];
-
-  // Dedupe by (nodeId48, seq16): same or older seq16 → refresh link metrics only.
-  const Seq16Order order = seq16_order(seq16, entry.last_seq);
-  if (order == Seq16Order::Same || order == Seq16Order::Older) {
-    entry.last_seen_ms = now_ms;
-    entry.last_rx_rssi = rssi_dbm;
-    set_dirty();
-    return true;
-  }
-
-  // Accepted: apply Informative fields. MUST NOT touch position.
-  entry.last_seq = seq16;
-  if (has_max_silence) {
-    entry.has_max_silence = true;
-    entry.max_silence_10s = max_silence_10s;
-  }
-  if (has_hw_profile) {
-    entry.has_hw_profile = true;
-    entry.hw_profile_id  = hw_profile_id;
-  }
-  if (has_fw_version) {
-    entry.has_fw_version = true;
-    entry.fw_version_id  = fw_version_id;
-  }
-  entry.last_seen_ms = now_ms;
-  entry.last_rx_rssi = rssi_dbm;
   set_dirty();
   return true;
 }

--- a/firmware/src/domain/node_table.h
+++ b/firmware/src/domain/node_table.h
@@ -40,11 +40,9 @@ struct NodeEntry {
   bool in_use = false;
 
   // ─── Runtime-local decoder state only (NOT canonical product truth; NOT in BLE; NOT persisted) ─
-  // Tail–Core correlation for apply_tail1; see product_truth_s03_v1 §7, seq_ref_version_link_metrics_v0.
+  // last_core_seq16 set by apply_pos_full (v0.2); used for seq tracking only (#438: no Tail).
   uint16_t last_core_seq16 = 0;
   bool     has_core_seq16  = false;
-  uint16_t last_applied_tail_ref_core_seq16 = 0;
-  bool     has_applied_tail_ref_core_seq16  = false;
 
   // ─── Battery / survivability ──────────────────────────────────────────────
   bool     has_battery       = false;
@@ -83,87 +81,6 @@ class NodeTable {
                      int8_t last_rx_rssi,
                      uint16_t last_seq,
                      uint32_t now_ms);
-
-  /**
-   * Apply Tail-1 (Node_OOTB_Core_Tail) fields to an existing NodeTable entry.
-   *
-   * Enforces the ref_core_seq16 match rule per tail1_packet_encoding_v0 §4.1:
-   * - Returns false (silent drop) if no Core has been received for node_id.
-   * - Returns false (silent drop) if ref_core_seq16 != last_core_seq16 for this node.
-   * - Returns true and applies posFlags/sats only on match.
-   * - MUST NOT update position fields.
-   *
-   * Per rx_semantics_v0: dedupe key is (nodeId48, seq16). If a second Tail-1
-   * arrives with the same seq16 for this node, it is treated as a duplicate
-   * and ignored (seq16 check happens before ref_core_seq16 check).
-   *
-   * @param node_id         NodeID48 from the Tail-1 payload.
-   * @param seq16           Tail-1's own global per-node counter (for dedupe).
-   * @param ref_core_seq16  ref_core_seq16 from the Tail-1 payload (Core linkage key).
-   * @param has_pos_flags   Whether posFlags is present.
-   * @param pos_flags       posFlags value (ignored if !has_pos_flags).
-   * @param has_sats        Whether sats is present.
-   * @param sats            sats value (ignored if !has_sats).
-   * @param rssi_dbm        Link metric from the received frame.
-   * @param now_ms          Current time for lastRxAt update.
-   * @return true if applied; false if dropped (duplicate, mismatch, or no prior Core).
-   */
-  bool apply_tail1(uint64_t node_id,
-                   uint16_t seq16,
-                   uint16_t ref_core_seq16,
-                   bool has_pos_flags, uint8_t pos_flags,
-                   bool has_sats, uint8_t sats,
-                   int8_t rssi_dbm,
-                   uint32_t now_ms);
-
-  /**
-   * Apply Tail-2 (Node_OOTB_Operational) fields to a NodeTable entry (create if not found).
-   *
-   * Deduplication by (nodeId48, seq16) per rx_semantics_v0.
-   * MUST NOT update position fields.
-   *
-   * @param node_id          NodeID48 from the Tail-2 payload.
-   * @param seq16            Global per-node counter from Common prefix (for dedupe).
-   * @param has_battery      Whether batteryPercent is present.
-   * @param battery_percent  batteryPercent value (ignored if !has_battery).
-   * @param has_uptime       Whether uptimeSec is present.
-   * @param uptime_sec       uptimeSec value (ignored if !has_uptime).
-   * @param rssi_dbm         Link metric from the received frame.
-   * @param now_ms           Current time for lastRxAt update.
-   * @return true on success; false only on table-full eviction failure.
-   */
-  bool apply_tail2(uint64_t node_id,
-                   uint16_t seq16,
-                   bool has_battery, uint8_t battery_percent,
-                   bool has_uptime, uint32_t uptime_sec,
-                   int8_t rssi_dbm,
-                   uint32_t now_ms);
-
-  /**
-   * Apply Info (Node_OOTB_Informative, 0x05) fields to a NodeTable entry (create if not found).
-   *
-   * Deduplication by (nodeId48, seq16) per rx_semantics_v0.
-   * MUST NOT update position fields.
-   *
-   * @param node_id          NodeID48 from the Info payload.
-   * @param seq16            Global per-node counter from Common prefix (for dedupe).
-   * @param has_max_silence  Whether maxSilence10s is present.
-   * @param max_silence_10s  maxSilence10s value (ignored if !has_max_silence).
-   * @param has_hw_profile   Whether hwProfileId is present.
-   * @param hw_profile_id    hwProfileId value (ignored if !has_hw_profile).
-   * @param has_fw_version   Whether fwVersionId is present.
-   * @param fw_version_id    fwVersionId value (ignored if !has_fw_version).
-   * @param rssi_dbm         Link metric from the received frame.
-   * @param now_ms           Current time for lastRxAt update.
-   * @return true on success; false only on table-full eviction failure.
-   */
-  bool apply_info(uint64_t node_id,
-                  uint16_t seq16,
-                  bool has_max_silence, uint8_t max_silence_10s,
-                  bool has_hw_profile, uint16_t hw_profile_id,
-                  bool has_fw_version, uint16_t fw_version_id,
-                  int8_t rssi_dbm,
-                  uint32_t now_ms);
 
   /**
    * Apply Node_Pos_Full v0.2 (#435): position + Pos_Quality in one step.

--- a/firmware/src/domain/nodetable_snapshot.cpp
+++ b/firmware/src/domain/nodetable_snapshot.cpp
@@ -119,8 +119,6 @@ void unpack_record(const uint8_t* in, NodeEntry* e, size_t record_bytes) {
   e->last_seq = 0;
   e->last_core_seq16 = 0;
   e->has_core_seq16 = false;
-  e->last_applied_tail_ref_core_seq16 = 0;
-  e->has_applied_tail_ref_core_seq16 = false;
   e->in_use = true;
 }
 

--- a/firmware/test/test_beacon_logic/test_beacon_logic.cpp
+++ b/firmware/test/test_beacon_logic/test_beacon_logic.cpp
@@ -253,43 +253,25 @@ void test_tx_payload_correctness() {
   TEST_ASSERT_EQUAL_UINT16(2, decoded.seq16);
 }
 
-// ── RX: Core dispatch ───────────────────────────────────────────────────────
+// ── RX: v0.2-only; v0.1 packets dropped (#438) ───────────────────────────────
 
-void test_rx_core_success_updates_node_table() {
+void test_rx_v01_packets_dropped() {
   BeaconLogic logic;
   NodeTable table;
-  table.set_expected_interval_s(10);
-
-  GeoBeaconFields fields{};
-  fields.node_id   = 0x0000030405060708ULL;
-  fields.pos_valid = 1;
-  fields.lat_deg   = 55.7558;
-  fields.lon_deg   = 37.6173;
-  fields.seq       = 42;
-
-  uint8_t frame[kGeoBeaconFrameSize] = {};
-  const size_t written = naviga::protocol::encode_geo_beacon(
-      fields, naviga::protocol::ByteSpan{frame, sizeof(frame)});
-  TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, written);
-
-  uint64_t rx_node_id = 0;
-  uint16_t rx_seq     = 0;
-  bool rx_pos_valid   = false;
-  PacketLogType rx_type = PacketLogType::ALIVE;
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -55, table,
-                               &rx_node_id, &rx_seq, &rx_pos_valid, &rx_type));
-  TEST_ASSERT_EQUAL_UINT64(fields.node_id, rx_node_id);
-  TEST_ASSERT_EQUAL_UINT16(42, rx_seq);
-  TEST_ASSERT_TRUE(rx_pos_valid);
-  TEST_ASSERT_EQUAL(static_cast<int>(PacketLogType::CORE), static_cast<int>(rx_type));
-  TEST_ASSERT_EQUAL_UINT32(1, table.size());
-
-  uint8_t page[NodeTable::kRecordBytes * 2] = {};
-  const size_t bytes = table.get_page(1000, 0, 10, page, sizeof(page));
-  TEST_ASSERT_EQUAL_UINT32(NodeTable::kRecordBytes, bytes);
-  TEST_ASSERT_EQUAL_UINT64(fields.node_id, read_u64_le(page));
-  TEST_ASSERT_EQUAL_INT8(-55, static_cast<int8_t>(page[23]));
-  TEST_ASSERT_EQUAL_UINT8(127, page[24]);  // #419: snr_last (127 = NA); last_seq not in BLE
+  // Minimal valid-looking frames for 0x01, 0x03, 0x04, 0x05: header + payload.
+  uint8_t core_frame[2 + 15] = {0x0F, 0x02, 0x00};
+  for (size_t i = 3; i < sizeof(core_frame); ++i) core_frame[i] = 0;
+  TEST_ASSERT_FALSE(logic.on_rx(1000, core_frame, sizeof(core_frame), -50, table));
+  uint8_t tail1_frame[2 + 11] = {0x0B, 0x06};
+  for (size_t i = 2; i < sizeof(tail1_frame); ++i) tail1_frame[i] = 0;
+  TEST_ASSERT_FALSE(logic.on_rx(1000, tail1_frame, sizeof(tail1_frame), -50, table));
+  uint8_t tail2_frame[2 + 9] = {0x09, 0x08};
+  for (size_t i = 2; i < sizeof(tail2_frame); ++i) tail2_frame[i] = 0;
+  TEST_ASSERT_FALSE(logic.on_rx(1000, tail2_frame, sizeof(tail2_frame), -50, table));
+  uint8_t info_frame[2 + 9] = {0x09, 0x0A};
+  for (size_t i = 2; i < sizeof(info_frame); ++i) info_frame[i] = 0;
+  TEST_ASSERT_FALSE(logic.on_rx(1000, info_frame, sizeof(info_frame), -50, table));
+  TEST_ASSERT_EQUAL_UINT32(0, table.size());
 }
 
 // ── RX: v0.2 Node_Pos_Full (0x06) and Node_Status (0x07) (#435) ───────────────
@@ -390,7 +372,7 @@ void test_rx_alive_success_updates_node_table() {
   TEST_ASSERT_EQUAL_UINT32(1, table.size());
 }
 
-// Alive and Core from same node: Alive does not overwrite Core position.
+// Alive and Pos_Full from same node: Alive does not overwrite position.
 void test_rx_alive_does_not_overwrite_core_position() {
   BeaconLogic logic;
   NodeTable table;
@@ -398,18 +380,20 @@ void test_rx_alive_does_not_overwrite_core_position() {
 
   const uint64_t node_id = 0x0000112233445566ULL;
 
-  // First: receive a Core packet.
-  GeoBeaconFields core{};
-  core.node_id   = node_id;
-  core.pos_valid = 1;
-  core.lat_deg   = 55.7558;
-  core.lon_deg   = 37.6173;
-  core.seq       = 1;
-  uint8_t core_frame[kGeoBeaconFrameSize] = {};
-  TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize,
-      naviga::protocol::encode_geo_beacon(core,
-          naviga::protocol::ByteSpan{core_frame, sizeof(core_frame)}));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, core_frame, kGeoBeaconFrameSize, -50, table));
+  // First: receive Node_Pos_Full (v0.2) with round coordinates so encode/decode is exact.
+  naviga::protocol::PosFullFields pos{};
+  pos.node_id = node_id;
+  pos.seq16   = 1;
+  pos.lat_deg = 55.0;
+  pos.lon_deg = 37.0;
+  pos.fix_type = 1;
+  pos.pos_sats = 0;
+  pos.pos_accuracy_bucket = 0;
+  pos.pos_flags_small = 0;
+  uint8_t pos_frame[naviga::protocol::kPosFullFrameSize] = {};
+  const size_t pos_len = naviga::protocol::encode_pos_full_frame(pos, pos_frame, sizeof(pos_frame));
+  TEST_ASSERT_EQUAL(naviga::protocol::kPosFullFrameSize, pos_len);
+  TEST_ASSERT_TRUE(logic.on_rx(1000, pos_frame, pos_len, -50, table));
 
   // Then: receive an Alive packet (seq=2, no position).
   AliveFields alive_f{};
@@ -420,8 +404,14 @@ void test_rx_alive_does_not_overwrite_core_position() {
       encode_alive_frame(alive_f, alive_frame, sizeof(alive_frame)));
   TEST_ASSERT_TRUE(logic.on_rx(2000, alive_frame, kAliveFrameMin, -60, table));
 
-  // Node table should still have the node (updated by Alive).
+  // Node table should still have the node; position must not be overwritten by Alive.
   TEST_ASSERT_EQUAL_UINT32(1, table.size());
+  NodeEntry entry{};
+  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
+  TEST_ASSERT_TRUE(entry.pos_valid);
+  // Allow small rounding from pos_full encode/decode (55.0/37.0 → lat_e7/lon_e7).
+  TEST_ASSERT_INT_WITHIN(100, 550000000, entry.lat_e7);
+  TEST_ASSERT_INT_WITHIN(100, 370000000, entry.lon_e7);
 }
 
 // ── RX: drop rules ──────────────────────────────────────────────────────────
@@ -457,16 +447,22 @@ void test_rx_payload_len_mismatch_dropped() {
   TEST_ASSERT_EQUAL_UINT32(0, table.size());
 }
 
-// ── decode_header: accepts 0x05 ──────────────────────────────────────────────
+// ── decode_header: v0.2-only; v0.1 msg_types rejected (#438) ─────────────────
 
-void test_decode_header_accepts_0x05() {
-  // msg_type=0x05, payload_len=9 → H=(0x05<<9)|9=0x0A09 → [0x09, 0x0A]
-  uint8_t frame[2] = {0x09, 0x0A};
+void test_decode_header_rejects_v01_msgtypes() {
   naviga::protocol::PacketHeader hdr{};
-  TEST_ASSERT_TRUE(naviga::protocol::decode_header(frame, sizeof(frame), &hdr));
-  TEST_ASSERT_EQUAL(static_cast<int>(naviga::protocol::MsgType::BeaconInfo),
-                    static_cast<int>(hdr.msg_type));
-  TEST_ASSERT_EQUAL_UINT8(9, hdr.payload_len);
+  // 0x01 Core
+  uint8_t f01[2] = {0x0F, 0x02};
+  TEST_ASSERT_FALSE(naviga::protocol::decode_header(f01, 2, &hdr));
+  // 0x03 Tail1
+  uint8_t f03[2] = {0x0B, 0x06};
+  TEST_ASSERT_FALSE(naviga::protocol::decode_header(f03, 2, &hdr));
+  // 0x04 Tail2
+  uint8_t f04[2] = {0x09, 0x08};
+  TEST_ASSERT_FALSE(naviga::protocol::decode_header(f04, 2, &hdr));
+  // 0x05 Info
+  uint8_t f05[2] = {0x09, 0x0A};
+  TEST_ASSERT_FALSE(naviga::protocol::decode_header(f05, 2, &hdr));
 }
 
 void test_decode_header_accepts_0x06() {
@@ -728,503 +724,7 @@ void test_info_decode_bad_version_dropped() {
       static_cast<int>(err));
 }
 
-// ── Tail-1 RX: apply-on-match / drop-on-mismatch ────────────────────────────
-
-// Helper: build a BeaconCore frame and inject it via on_rx to seed last_core_seq16.
-static void seed_core(BeaconLogic& /*logic*/, NodeTable& table,
-                      uint64_t node_id, uint16_t seq, uint32_t now_ms) {
-  GeoBeaconFields core{};
-  core.node_id   = node_id;
-  core.pos_valid = 1;
-  core.lat_deg   = 55.0;
-  core.lon_deg   = 37.0;
-  core.seq       = seq;
-
-  uint8_t frame[kGeoBeaconFrameSize] = {};
-  using naviga::protocol::ByteSpan;
-  const size_t written = naviga::protocol::encode_geo_beacon(
-      core, ByteSpan{frame, sizeof(frame)});
-  (void)written;
-
-  BeaconLogic seeder;
-  seeder.on_rx(now_ms, frame, kGeoBeaconFrameSize, -50, table);
-}
-
-void test_tail1_rx_apply_on_match() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-  const uint16_t core_seq = 7;
-
-  seed_core(logic, table, node_id, core_seq, 1000);
-  TEST_ASSERT_EQUAL_UINT32(1, table.size());
-
-  // Build Tail-1 frame with matching ref_core_seq16=7, own seq16=8, posFlags=0x01, sats=8.
-  Tail1Fields t1{};
-  t1.node_id          = node_id;
-  t1.seq16            = 8;  // own global counter (newer than core_seq=7)
-  t1.ref_core_seq16   = core_seq;
-  t1.has_pos_flags    = true;
-  t1.pos_flags     = 0x01;
-  t1.has_sats      = true;
-  t1.sats          = 8;
-  uint8_t frame[kTail1FrameMax] = {};
-  const size_t written = encode_tail1_frame(t1, frame, sizeof(frame));
-  TEST_ASSERT_EQUAL_UINT32(kTail1FrameMax, written);
-
-  PacketLogType ptype = PacketLogType::CORE;
-  uint16_t out_core_seq = 0;
-  uint16_t out_seq = 0;
-  TEST_ASSERT_TRUE(logic.on_rx(2000, frame, written, -55, table,
-                               nullptr, &out_seq, nullptr, &ptype, &out_core_seq));
-  TEST_ASSERT_EQUAL_INT(static_cast<int>(PacketLogType::TAIL1), static_cast<int>(ptype));  // RX compat: still TAIL1 for 0x03
-  TEST_ASSERT_EQUAL_UINT16(8, out_seq);
-  TEST_ASSERT_EQUAL_UINT16(core_seq, out_core_seq);
-
-  // Verify posFlags and sats were applied.
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_TRUE(entry.has_pos_flags);
-  TEST_ASSERT_EQUAL_HEX8(0x01, entry.pos_flags);
-  TEST_ASSERT_TRUE(entry.has_sats);
-  TEST_ASSERT_EQUAL_UINT8(8, entry.sats);
-}
-
-void test_tail1_rx_drop_on_mismatch() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-  const uint16_t core_seq = 7;
-
-  seed_core(logic, table, node_id, core_seq, 1000);
-
-  // Build Tail-1 with stale ref_core_seq16=5 (mismatch), own seq16=8.
-  Tail1Fields t1{};
-  t1.node_id          = node_id;
-  t1.seq16            = 8;
-  t1.ref_core_seq16   = 5;  // != 7
-  t1.has_pos_flags = true;
-  t1.pos_flags     = 0x01;
-  t1.has_sats      = true;
-  t1.sats          = 12;
-  uint8_t frame[kTail1FrameMax] = {};
-  encode_tail1_frame(t1, frame, sizeof(frame));
-
-  // on_rx returns true (valid frame) but apply_tail1 drops internally.
-  TEST_ASSERT_TRUE(logic.on_rx(2000, frame, kTail1FrameMax, -55, table));
-
-  // posFlags/sats MUST NOT have been applied.
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_FALSE(entry.has_pos_flags);
-  TEST_ASSERT_FALSE(entry.has_sats);
-}
-
-void test_tail1_rx_drop_no_prior_core() {
-  BeaconLogic logic;
-  NodeTable table;
-  // No Core seeded — node not in table.
-  Tail1Fields t1{};
-  t1.node_id          = 0x0000AABBCCDDEEFFULL;
-  t1.seq16            = 1;
-  t1.ref_core_seq16   = 1;
-  uint8_t frame[kTail1FrameMin] = {};
-  encode_tail1_frame(t1, frame, sizeof(frame));
-
-  // on_rx returns true (valid frame), but apply_tail1 drops (no entry).
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, kTail1FrameMin, -55, table));
-  TEST_ASSERT_EQUAL_UINT32(0, table.size());
-}
-
-void test_tail1_rx_bad_version_dropped() {
-  BeaconLogic logic;
-  NodeTable table;
-  // Manually craft a Tail-1 frame with payloadVersion=0x01.
-  // Header: msg_type=0x03, payload_len=11 → [0x0B, 0x06]
-  uint8_t frame[kTail1FrameMin] = {0x0B, 0x06,
-                                    0x01,  // bad payloadVersion
-                                    0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA,
-                                    0x01, 0x00,  // seq16
-                                    0x01, 0x00}; // ref_core_seq16
-  TEST_ASSERT_FALSE(logic.on_rx(1000, frame, sizeof(frame), -55, table));
-}
-
-// ── Tail-1 RX: duplicate suppression ────────────────────────────────────────
-
-void test_tail1_rx_duplicate_seq16_ignored() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-  const uint16_t core_seq = 7;
-
-  seed_core(logic, table, node_id, core_seq, 1000);
-
-  // First Tail-1: seq16=8, ref=7, sats=8.
-  Tail1Fields t1{};
-  t1.node_id        = node_id;
-  t1.seq16          = 8;
-  t1.ref_core_seq16 = core_seq;
-  t1.has_sats       = true;
-  t1.sats           = 8;
-  uint8_t frame[kTail1FrameMax] = {};
-  encode_tail1_frame(t1, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(2000, frame, kTail1FrameMax, -55, table));
-
-  // Second Tail-1: same seq16=8 (duplicate), different sats=99.
-  t1.sats = 99;
-  encode_tail1_frame(t1, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(2100, frame, kTail1FrameMax, -55, table));
-
-  // sats MUST still be 8 (first apply wins; duplicate ignored).
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_EQUAL_UINT8(8, entry.sats);
-}
-
-// ── Tail-1 RX: Variant 2 — one tail per Core sample ─────────────────────────
-
-void test_tail1_rx_variant2_second_tail_same_ref_ignored() {
-  // Arrange: Core with seq=100.
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-  const uint16_t core_seq = 100;
-
-  seed_core(logic, table, node_id, core_seq, 1000);
-
-  // Apply first Tail-1: seq16=101, ref_core_seq16=100, sats=8 → should apply.
-  Tail1Fields t1a{};
-  t1a.node_id        = node_id;
-  t1a.seq16          = 101;
-  t1a.ref_core_seq16 = core_seq;
-  t1a.has_sats       = true;
-  t1a.sats           = 8;
-  uint8_t frame[kTail1FrameMax] = {};
-  encode_tail1_frame(t1a, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(2000, frame, kTail1FrameMax, -55, table));
-
-  NodeEntry after_first{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &after_first));
-  TEST_ASSERT_TRUE(after_first.has_sats);
-  TEST_ASSERT_EQUAL_UINT8(8, after_first.sats);
-
-  // Apply second Tail-1: seq16=102 (different!), ref_core_seq16=100 (same!) → must be ignored.
-  Tail1Fields t1b{};
-  t1b.node_id        = node_id;
-  t1b.seq16          = 102;
-  t1b.ref_core_seq16 = core_seq;  // same ref as first
-  t1b.has_sats       = true;
-  t1b.sats           = 99;  // different value — must not overwrite
-  encode_tail1_frame(t1b, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(2100, frame, kTail1FrameMax, -55, table));
-
-  // sats MUST still be 8 (Variant 2: second tail for same Core sample ignored).
-  NodeEntry after_second{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &after_second));
-  TEST_ASSERT_EQUAL_UINT8(8, after_second.sats);
-}
-
-void test_tail1_rx_variant2_new_core_resets_tail_gate() {
-  // After a new Core_Pos is received, a new Tail-1 for the new Core sample must apply.
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  // First Core: seq=100.
-  seed_core(logic, table, node_id, 100, 1000);
-
-  // First Tail-1: seq16=101, ref=100, sats=8 → applied.
-  Tail1Fields t1a{};
-  t1a.node_id        = node_id;
-  t1a.seq16          = 101;
-  t1a.ref_core_seq16 = 100;
-  t1a.has_sats       = true;
-  t1a.sats           = 8;
-  uint8_t frame[kTail1FrameMax] = {};
-  encode_tail1_frame(t1a, frame, sizeof(frame));
-  logic.on_rx(2000, frame, kTail1FrameMax, -55, table);
-
-  // Second Core: seq=102 → updates last_core_seq16 to 102.
-  seed_core(logic, table, node_id, 102, 3000);
-
-  // Tail-1 for new Core: seq16=103, ref=102, sats=15 → must apply (new Core sample).
-  Tail1Fields t1b{};
-  t1b.node_id        = node_id;
-  t1b.seq16          = 103;
-  t1b.ref_core_seq16 = 102;
-  t1b.has_sats       = true;
-  t1b.sats           = 15;
-  encode_tail1_frame(t1b, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(4000, frame, kTail1FrameMax, -55, table));
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_EQUAL_UINT8(15, entry.sats);
-}
-
-// ── Tail-2 (Operational) RX ──────────────────────────────────────────────────
-
-void test_tail2_rx_applies_battery() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  Tail2Fields t2{};
-  t2.node_id      = node_id;
-  t2.seq16        = 5;
-  t2.has_battery  = true;
-  t2.battery_percent = 80;
-
-  uint8_t frame[kTail2FrameMax] = {};
-  const size_t written = encode_tail2_frame(t2, frame, sizeof(frame));
-
-  PacketLogType ptype = PacketLogType::CORE;
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -60, table,
-                               nullptr, nullptr, nullptr, &ptype));
-  TEST_ASSERT_EQUAL_INT(static_cast<int>(PacketLogType::TAIL2), static_cast<int>(ptype));  // RX compat: 0x04 → TAIL2
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_TRUE(entry.has_battery);
-  TEST_ASSERT_EQUAL_UINT8(80, entry.battery_percent);
-}
-
-void test_tail2_rx_no_prior_core_creates_entry() {
-  // Tail-2 can arrive before Core; it should create an entry.
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000112233445566ULL;
-
-  Tail2Fields t2{};
-  t2.node_id      = node_id;
-  t2.seq16        = 3;
-  t2.has_battery  = true;
-  t2.battery_percent = 80;
-
-  uint8_t frame[kTail2FrameMax] = {};
-  const size_t written = encode_tail2_frame(t2, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -70, table));
-  TEST_ASSERT_EQUAL_UINT32(1, table.size());
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_TRUE(entry.has_battery);
-  TEST_ASSERT_EQUAL_UINT8(80, entry.battery_percent);
-  // Position MUST NOT have been set.
-  TEST_ASSERT_FALSE(entry.pos_valid);
-  TEST_ASSERT_EQUAL_INT32(0, entry.lat_e7);
-  TEST_ASSERT_EQUAL_INT32(0, entry.lon_e7);
-}
-
-void test_tail2_rx_bad_version_dropped() {
-  BeaconLogic logic;
-  NodeTable table;
-  // Header: msg_type=0x04, payload_len=9 → [0x09, 0x08]; bad payloadVersion=0x01
-  uint8_t frame[kTail2FrameMin] = {0x09, 0x08,
-                                    0x01,  // bad payloadVersion
-                                    0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA,
-                                    0x01, 0x00};
-  TEST_ASSERT_FALSE(logic.on_rx(1000, frame, sizeof(frame), -60, table));
-  TEST_ASSERT_EQUAL_UINT32(0, table.size());
-}
-
-// ── Info (Informative) RX ────────────────────────────────────────────────────
-
-void test_info_rx_applies_max_silence() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  InfoFields info{};
-  info.node_id         = node_id;
-  info.seq16           = 6;
-  info.has_max_silence = true;
-  info.max_silence_10s = 9;  // 90 s
-
-  uint8_t frame[kInfoFrameMax] = {};
-  const size_t written = encode_info_frame(info, frame, sizeof(frame));
-
-  PacketLogType ptype = PacketLogType::CORE;
-  uint16_t out_seq = 0;
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -60, table,
-                               nullptr, &out_seq, nullptr, &ptype));
-  TEST_ASSERT_EQUAL_INT(static_cast<int>(PacketLogType::INFO), static_cast<int>(ptype));
-  TEST_ASSERT_EQUAL_UINT16(6, out_seq);
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_TRUE(entry.has_max_silence);
-  TEST_ASSERT_EQUAL_UINT8(9, entry.max_silence_10s);
-}
-
-void test_info_rx_full_fields() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000112233445566ULL;
-
-  InfoFields info{};
-  info.node_id        = node_id;
-  info.seq16          = 10;
-  info.has_max_silence = true;
-  info.max_silence_10s = 6;
-  info.has_hw_profile  = true;
-  info.hw_profile_id   = 0x0201;
-  info.has_fw_version  = true;
-  info.fw_version_id   = 0x0302;
-
-  uint8_t frame[kInfoFrameMax] = {};
-  const size_t written = encode_info_frame(info, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -55, table));
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  TEST_ASSERT_TRUE(entry.has_max_silence);
-  TEST_ASSERT_EQUAL_UINT8(6, entry.max_silence_10s);
-  TEST_ASSERT_TRUE(entry.has_hw_profile);
-  TEST_ASSERT_EQUAL_UINT16(0x0201, entry.hw_profile_id);
-  TEST_ASSERT_TRUE(entry.has_fw_version);
-  TEST_ASSERT_EQUAL_UINT16(0x0302, entry.fw_version_id);
-  // Position MUST NOT have been set.
-  TEST_ASSERT_FALSE(entry.pos_valid);
-}
-
-void test_info_rx_no_prior_core_creates_entry() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  InfoFields info{};
-  info.node_id         = node_id;
-  info.seq16           = 1;
-  info.has_max_silence = true;
-  info.max_silence_10s = 3;
-
-  uint8_t frame[kInfoFrameMax] = {};
-  const size_t written = encode_info_frame(info, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, written, -70, table));
-  TEST_ASSERT_EQUAL_UINT32(1, table.size());
-}
-
-void test_info_rx_bad_version_dropped() {
-  BeaconLogic logic;
-  NodeTable table;
-  // Header: msg_type=0x05, payload_len=9 → [0x09, 0x0A]; bad payloadVersion=0x01
-  uint8_t frame[kInfoFrameMin] = {0x09, 0x0A,
-                                   0x01,  // bad payloadVersion
-                                   0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA,
-                                   0x01, 0x00};
-  TEST_ASSERT_FALSE(logic.on_rx(1000, frame, sizeof(frame), -60, table));
-  TEST_ASSERT_EQUAL_UINT32(0, table.size());
-}
-
-// ── RX dedupe: (nodeId48, seq16) ─────────────────────────────────────────────
-
-void test_rx_dedupe_operational_same_seq16_ignored() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  // First Tail-2: seq16=5, battery=80.
-  Tail2Fields t2{};
-  t2.node_id         = node_id;
-  t2.seq16           = 5;
-  t2.has_battery     = true;
-  t2.battery_percent = 80;
-  uint8_t frame[kTail2FrameMax] = {};
-  encode_tail2_frame(t2, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, kTail2FrameMin + 1, -60, table));
-
-  // Second Tail-2: same seq16=5, battery=99 (duplicate).
-  t2.battery_percent = 99;
-  encode_tail2_frame(t2, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1100, frame, kTail2FrameMin + 1, -60, table));
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  // battery MUST still be 80 (first apply wins; duplicate ignored).
-  TEST_ASSERT_EQUAL_UINT8(80, entry.battery_percent);
-}
-
-void test_rx_dedupe_info_same_seq16_ignored() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-
-  // First Info: seq16=3, maxSilence=6.
-  InfoFields info{};
-  info.node_id         = node_id;
-  info.seq16           = 3;
-  info.has_max_silence = true;
-  info.max_silence_10s = 6;
-  uint8_t frame[kInfoFrameMax] = {};
-  encode_info_frame(info, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1000, frame, kInfoFrameMin + 1, -60, table));
-
-  // Second Info: same seq16=3, maxSilence=99 (duplicate).
-  info.max_silence_10s = 99;
-  encode_info_frame(info, frame, sizeof(frame));
-  TEST_ASSERT_TRUE(logic.on_rx(1100, frame, kInfoFrameMin + 1, -60, table));
-
-  NodeEntry entry{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &entry));
-  // maxSilence MUST still be 6 (first apply wins; duplicate ignored).
-  TEST_ASSERT_EQUAL_UINT8(6, entry.max_silence_10s);
-}
-
-// ── Position invariant: Tail never overwrites position ───────────────────────
-
-void test_tail_never_overwrites_position() {
-  BeaconLogic logic;
-  NodeTable table;
-  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
-  const uint16_t core_seq = 3;
-
-  // Seed Core with known position.
-  seed_core(logic, table, node_id, core_seq, 1000);
-  NodeEntry before{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &before));
-  TEST_ASSERT_TRUE(before.pos_valid);
-  const int32_t saved_lat = before.lat_e7;
-  const int32_t saved_lon = before.lon_e7;
-
-  // Apply matching Tail-1.
-  Tail1Fields t1{};
-  t1.node_id          = node_id;
-  t1.seq16            = 4;  // newer than core_seq=3
-  t1.ref_core_seq16   = core_seq;
-  t1.has_pos_flags    = true;
-  t1.pos_flags     = 0x01;
-  uint8_t t1_frame[kTail1FrameMax] = {};
-  encode_tail1_frame(t1, t1_frame, sizeof(t1_frame));
-  logic.on_rx(2000, t1_frame, kTail1FrameMax, -55, table);
-
-  // Apply Tail-2 (Operational).
-  Tail2Fields t2{};
-  t2.node_id     = node_id;
-  t2.seq16       = 5;
-  t2.has_battery = true;
-  t2.battery_percent = 90;
-  uint8_t t2_frame[kTail2FrameMax] = {};
-  const size_t t2_written = encode_tail2_frame(t2, t2_frame, sizeof(t2_frame));
-  logic.on_rx(3000, t2_frame, t2_written, -60, table);
-
-  // Apply Info (Informative).
-  InfoFields info{};
-  info.node_id         = node_id;
-  info.seq16           = 6;
-  info.has_max_silence = true;
-  info.max_silence_10s = 9;
-  uint8_t info_frame[kInfoFrameMax] = {};
-  const size_t info_written = encode_info_frame(info, info_frame, sizeof(info_frame));
-  logic.on_rx(4000, info_frame, info_written, -60, table);
-
-  // Position MUST be unchanged.
-  NodeEntry after{};
-  TEST_ASSERT_TRUE(table.find_entry_for_test(node_id, &after));
-  TEST_ASSERT_TRUE(after.pos_valid);
-  TEST_ASSERT_EQUAL_INT32(saved_lat, after.lat_e7);
-  TEST_ASSERT_EQUAL_INT32(saved_lon, after.lon_e7);
-}
+// (v0.1 RX tests removed #438; codec tests for tail1/tail2/info remain above.)
 
 // ── TX queue: helpers ────────────────────────────────────────────────────────
 
@@ -1980,7 +1480,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_tx_no_fix_at_max_silence_sends_alive);
   RUN_TEST(test_tx_min_interval_no_update_no_send);
   RUN_TEST(test_tx_payload_correctness);
-  RUN_TEST(test_rx_core_success_updates_node_table);
+  RUN_TEST(test_rx_v01_packets_dropped);
   RUN_TEST(test_rx_pos_full_applies_position_and_quality);
   RUN_TEST(test_rx_status_applies_full_snapshot);
   RUN_TEST(test_rx_alive_success_updates_node_table);
@@ -1988,8 +1488,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_rx_invalid_frame_too_short);
   RUN_TEST(test_rx_unknown_msgtype_dropped);
   RUN_TEST(test_rx_payload_len_mismatch_dropped);
-  // decode_header 0x05
-  RUN_TEST(test_decode_header_accepts_0x05);
+  RUN_TEST(test_decode_header_rejects_v01_msgtypes);
   RUN_TEST(test_decode_header_accepts_0x06);
   // Tail-1 codec
   RUN_TEST(test_tail1_codec_base_round_trip);
@@ -2005,28 +1504,6 @@ int main(int argc, char** argv) {
   RUN_TEST(test_info_codec_base_round_trip);
   RUN_TEST(test_info_codec_full_round_trip);
   RUN_TEST(test_info_decode_bad_version_dropped);
-  // Tail-1 RX dispatch
-  RUN_TEST(test_tail1_rx_apply_on_match);
-  RUN_TEST(test_tail1_rx_drop_on_mismatch);
-  RUN_TEST(test_tail1_rx_drop_no_prior_core);
-  RUN_TEST(test_tail1_rx_bad_version_dropped);
-  RUN_TEST(test_tail1_rx_duplicate_seq16_ignored);
-  RUN_TEST(test_tail1_rx_variant2_second_tail_same_ref_ignored);
-  RUN_TEST(test_tail1_rx_variant2_new_core_resets_tail_gate);
-  // Tail-2 RX dispatch
-  RUN_TEST(test_tail2_rx_applies_battery);
-  RUN_TEST(test_tail2_rx_no_prior_core_creates_entry);
-  RUN_TEST(test_tail2_rx_bad_version_dropped);
-  // Info RX dispatch
-  RUN_TEST(test_info_rx_applies_max_silence);
-  RUN_TEST(test_info_rx_full_fields);
-  RUN_TEST(test_info_rx_no_prior_core_creates_entry);
-  RUN_TEST(test_info_rx_bad_version_dropped);
-  // Dedupe
-  RUN_TEST(test_rx_dedupe_operational_same_seq16_ignored);
-  RUN_TEST(test_rx_dedupe_info_same_seq16_ignored);
-  // Position invariant
-  RUN_TEST(test_tail_never_overwrites_position);
   // TX queue: formation
   RUN_TEST(test_txq_core_enqueues_tail_with_correct_ref);
   RUN_TEST(test_txq_tail1_not_enqueued_without_core);

--- a/firmware/test/test_geo_beacon_codec/test_geo_beacon_codec.cpp
+++ b/firmware/test/test_geo_beacon_codec/test_geo_beacon_codec.cpp
@@ -58,21 +58,21 @@ void test_header_golden_encode() {
 }
 
 void test_header_golden_decode() {
-  const uint8_t wire[2] = {0x0F, 0x02};
+  // v0.2-accepted type: BeaconAlive (0x02), payload_len=9 → H=0x0409 → [0x09, 0x04] (#438).
+  const uint8_t wire[2] = {0x09, 0x04};
   PacketHeader hdr;
   TEST_ASSERT_TRUE(decode_header(wire, sizeof(wire), &hdr));
-  TEST_ASSERT_EQUAL(static_cast<int>(MsgType::BeaconCore), static_cast<int>(hdr.msg_type));
+  TEST_ASSERT_EQUAL(static_cast<int>(MsgType::BeaconAlive), static_cast<int>(hdr.msg_type));
   TEST_ASSERT_EQUAL_UINT8(0, hdr.reserved);
-  TEST_ASSERT_EQUAL_UINT8(15, hdr.payload_len);
+  TEST_ASSERT_EQUAL_UINT8(9, hdr.payload_len);
 }
 
-// Encode/decode round-trip for all registered msg_types.
+// Encode/decode round-trip for v0.2-accepted msg_types only (#438).
 void test_header_roundtrip_all_types() {
   const MsgType types[] = {
-      MsgType::BeaconCore,
       MsgType::BeaconAlive,
-      MsgType::BeaconTail1,
-      MsgType::BeaconTail2,
+      MsgType::BeaconPosFull,
+      MsgType::BeaconStatus,
   };
   for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); ++i) {
     PacketHeader hdr;
@@ -91,6 +91,19 @@ void test_header_roundtrip_all_types() {
   }
 }
 
+// v0.1 msg_types (0x01, 0x03, 0x04, 0x05) must be rejected on decode (#438).
+void test_header_decode_v01_msgtypes_rejected() {
+  PacketHeader hdr;
+  uint8_t f01[2] = {0x0F, 0x02};  // 0x01 Core
+  TEST_ASSERT_FALSE(decode_header(f01, 2, &hdr));
+  uint8_t f03[2] = {0x0B, 0x06};  // 0x03 Tail1
+  TEST_ASSERT_FALSE(decode_header(f03, 2, &hdr));
+  uint8_t f04[2] = {0x09, 0x08};  // 0x04 Tail2
+  TEST_ASSERT_FALSE(decode_header(f04, 2, &hdr));
+  uint8_t f05[2] = {0x09, 0x0A};  // 0x05 Info
+  TEST_ASSERT_FALSE(decode_header(f05, 2, &hdr));
+}
+
 // Reserved msg_type (0x00) must be rejected on decode.
 void test_header_decode_reserved_msgtype_rejected() {
   const uint8_t wire[2] = {0x00, 0x00};  // msg_type=0x00
@@ -98,7 +111,7 @@ void test_header_decode_reserved_msgtype_rejected() {
   TEST_ASSERT_FALSE(decode_header(wire, sizeof(wire), &hdr));
 }
 
-// Unknown msg_type (> BeaconTail2) must be rejected on decode.
+// Unknown msg_type (> BeaconStatus) must be rejected on decode.
 void test_header_decode_unknown_msgtype_rejected() {
   // msg_type=0x7F (127), payload_len=9:
   // H = (0x7F << 9) | 9 = 0xFF09  →  byte0=0x09, byte1=0xFF
@@ -107,15 +120,14 @@ void test_header_decode_unknown_msgtype_rejected() {
   TEST_ASSERT_FALSE(decode_header(wire, sizeof(wire), &hdr));
 }
 
-// Non-zero reserved bits must be accepted (forward-compat).
+// Non-zero reserved bits must be accepted (forward-compat). Use v0.2-accepted type 0x02.
 void test_header_decode_nonzero_reserved_accepted() {
-  // Encode manually with reserved=0x07 (all 3 bits set):
-  // byte0 = ((0x07 & 0x3) << 6) | 9 = (3<<6)|9 = 0xC9
-  // byte1 = (0x01 << 1) | (0x07 >> 2) = 2 | 1 = 0x03
-  const uint8_t wire[2] = {0xC9, 0x03};
+  // msg_type=0x02 (BeaconAlive), reserved=0x07, payload_len=9:
+  // byte0 = ((0x07 & 0x3) << 6) | 9 = 0xC9, byte1 = (0x02 << 1) | (0x07 >> 2) = 0x05
+  const uint8_t wire[2] = {0xC9, 0x05};
   PacketHeader hdr;
   TEST_ASSERT_TRUE(decode_header(wire, sizeof(wire), &hdr));
-  TEST_ASSERT_EQUAL(static_cast<int>(MsgType::BeaconCore), static_cast<int>(hdr.msg_type));
+  TEST_ASSERT_EQUAL(static_cast<int>(MsgType::BeaconAlive), static_cast<int>(hdr.msg_type));
   TEST_ASSERT_EQUAL_UINT8(9, hdr.payload_len);
 }
 
@@ -198,7 +210,8 @@ void test_framed_core_golden_decode() {
   };
 
   GeoBeaconFields out{};
-  const DecodeError err = decode_geo_beacon_frame(ConstByteSpan{frame, sizeof(frame)}, &out);
+  // #438: decode_header rejects 0x01; test payload decode only (frame header no longer accepted on RX).
+  const DecodeError err = decode_geo_beacon(ConstByteSpan{frame + kHeaderSize, sizeof(frame) - kHeaderSize}, &out);
   TEST_ASSERT_EQUAL(DecodeError::Ok, err);
   TEST_ASSERT_EQUAL_UINT64(0x0000AABBCCDDEEFFULL, out.node_id);
   TEST_ASSERT_EQUAL_UINT16(1, out.seq);
@@ -220,17 +233,16 @@ void test_framed_core_decode_wrong_msgtype_rejected() {
   TEST_ASSERT_EQUAL(DecodeError::BadMsgType, err);
 }
 
-// decode_geo_beacon_frame rejects payload_len mismatch.
+// decode_geo_beacon_frame rejects payload_len mismatch (or BadMsgType when 0x01 rejected #438).
 void test_framed_core_decode_payload_len_mismatch_rejected() {
-  // Build a valid 17-byte frame but with payload_len=14 in header (wrong).
-  // H = (0x01<<9)|14 = 0x020E → byte0=0x0E, byte1=0x02
+  // Frame with 0x01: decode_header now rejects 0x01 (#438), so we get BadMsgType before PayloadLenMismatch.
   uint8_t frame[17] = {};
   frame[0] = 0x0E;
   frame[1] = 0x02;
   frame[2] = kGeoBeaconPayloadVersion;
   GeoBeaconFields out{};
   const DecodeError err = decode_geo_beacon_frame(ConstByteSpan{frame, sizeof(frame)}, &out);
-  TEST_ASSERT_EQUAL(DecodeError::PayloadLenMismatch, err);
+  TEST_ASSERT_EQUAL(DecodeError::BadMsgType, err);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -292,7 +304,7 @@ void test_round_trip() {
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, written);
 
   GeoBeaconFields out{};
-  const DecodeError err = decode_geo_beacon_frame(ConstByteSpan{buf, written}, &out);
+  const DecodeError err = decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, written - kHeaderSize}, &out);
   TEST_ASSERT_EQUAL(DecodeError::Ok, err);
   TEST_ASSERT_EQUAL_UINT64(in.node_id, out.node_id);
   TEST_ASSERT_EQUAL_UINT16(in.seq, out.seq);
@@ -312,19 +324,19 @@ void test_round_trip_extremes() {
 
   in.lat_deg = 90.0; in.lon_deg = 180.0;
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_TRUE(deg_near(out.lat_deg, 90.0, kDegTol));
   TEST_ASSERT_TRUE(deg_near(out.lon_deg, 180.0, kDegTol));
 
   in.lat_deg = -90.0; in.lon_deg = -180.0;
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_TRUE(deg_near(out.lat_deg, -90.0, kDegTol));
   TEST_ASSERT_TRUE(deg_near(out.lon_deg, -180.0, kDegTol));
 
   in.lat_deg = 0.0; in.lon_deg = 0.0;
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_TRUE(deg_near(out.lat_deg, 0.0, kDegTol));
   TEST_ASSERT_TRUE(deg_near(out.lon_deg, 0.0, kDegTol));
 }
@@ -335,7 +347,7 @@ void test_clamp_out_of_range_lat() {
   uint8_t buf[kGeoBeaconFrameSize] = {};
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
   GeoBeaconFields out{};
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_TRUE(deg_near(out.lat_deg, 90.0, kDegTol));
 }
 
@@ -345,7 +357,7 @@ void test_clamp_out_of_range_lon() {
   uint8_t buf[kGeoBeaconFrameSize] = {};
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
   GeoBeaconFields out{};
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_TRUE(deg_near(out.lon_deg, -180.0, kDegTol));
 }
 
@@ -378,7 +390,7 @@ void test_bad_payload_version() {
   buf[kHeaderSize] = 0xFF;  // corrupt payloadVersion
   GeoBeaconFields out{};
   TEST_ASSERT_EQUAL(DecodeError::BadPayloadVersion,
-                    decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+                    decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
 }
 
 void test_nodeid48_upper_bits_stripped() {
@@ -388,7 +400,7 @@ void test_nodeid48_upper_bits_stripped() {
   uint8_t buf[kGeoBeaconFrameSize] = {};
   TEST_ASSERT_EQUAL_UINT32(kGeoBeaconFrameSize, encode_geo_beacon(in, ByteSpan{buf, sizeof(buf)}));
   GeoBeaconFields out{};
-  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon_frame(ConstByteSpan{buf, sizeof(buf)}, &out));
+  TEST_ASSERT_EQUAL(DecodeError::Ok, decode_geo_beacon(ConstByteSpan{buf + kHeaderSize, kGeoBeaconSize}, &out));
   TEST_ASSERT_EQUAL_UINT64(0x0000001122334455ULL, out.node_id);
 }
 
@@ -541,6 +553,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_header_roundtrip_all_types);
   RUN_TEST(test_header_decode_reserved_msgtype_rejected);
   RUN_TEST(test_header_decode_unknown_msgtype_rejected);
+  RUN_TEST(test_header_decode_v01_msgtypes_rejected);
   RUN_TEST(test_header_decode_nonzero_reserved_accepted);
   RUN_TEST(test_header_validate);
   RUN_TEST(test_header_encode_payload_len_overflow_rejected);

--- a/firmware/test/test_node_table_domain/test_node_table_domain.cpp
+++ b/firmware/test/test_node_table_domain/test_node_table_domain.cpp
@@ -403,7 +403,7 @@ void test_nodetable_snapshot_restore_is_self_derived() {
   TEST_ASSERT_EQUAL_UINT16(0, e_remote.last_core_seq16);
 }
 
-// #418: excluded fields (last_seq, last_rx_rssi, last_applied_tail_ref*, last_core_seq16, has_core_seq16) not persisted; restore sets them 0/false.
+// #418: excluded fields (last_seq, last_rx_rssi, last_core_seq16, has_core_seq16) not persisted; restore sets them 0/false. (#438: last_applied_tail_ref* removed.)
 void test_nodetable_snapshot_excluded_fields_not_authoritative() {
   NodeTable table;
   table.set_expected_interval_s(18);
@@ -421,7 +421,6 @@ void test_nodetable_snapshot_excluded_fields_not_authoritative() {
     TEST_ASSERT_EQUAL_UINT32(0, entries[i].last_seen_ms);
     TEST_ASSERT_EQUAL(0, entries[i].last_seq);
     TEST_ASSERT_EQUAL(0, entries[i].last_rx_rssi);
-    TEST_ASSERT_FALSE(entries[i].has_applied_tail_ref_core_seq16);
     TEST_ASSERT_FALSE(entries[i].has_core_seq16);
     TEST_ASSERT_EQUAL_UINT16(0, entries[i].last_core_seq16);
   }


### PR DESCRIPTION
## Summary

This PR completes **#438**: final v0.2 protocol cutover. It removes the temporary v0.1 RX compatibility layer and finalizes protocol truth as **TX = v0.2 only**, **RX = v0.2 only**.

## What changed

- **`decode_header`** (packet_header.h): Rejects v0.1 msg_types 0x01, 0x03, 0x04, 0x05; accepts only 0x02 (Alive), 0x06 (Pos_Full), 0x07 (Status).
- **BeaconLogic RX**: Removed RX branches for BeaconCore, BeaconTail1, BeaconTail2, BeaconInfo; removed tail1/tail2/info codec includes.
- **NodeTable**: Removed `apply_tail1`, `apply_tail2`, `apply_info`; removed `last_applied_tail_ref_core_seq16` and `has_applied_tail_ref_core_seq16` from NodeEntry. **upsert_remote:** Alive (pos_valid=false) no longer overwrites position; only last_seq, last_seen_ms, last_rx_rssi updated (per packet_truth_table_v02).
- **nodetable_snapshot:** unpack_record no longer sets removed ref-tail fields.
- **Tests:** v0.1 RX tests removed; added `test_rx_v01_packets_dropped`, `test_decode_header_rejects_v01_msgtypes`; `test_rx_alive_does_not_overwrite_core_position` uses Pos_Full seed; test_geo_beacon_codec header/roundtrip limited to v0.2 types and reject tests for v0.1.
- **Docs:** packet_migration_v01_v02.md and packet_sets_v0.md state cutover complete; RX v0.2-only.

## Final protocol state

- **Packet family:** Node_Pos_Full (0x06), Node_Status (0x07), Alive (0x02) — see packet_truth_table_v02.md.
- **RX:** Only 0x02, 0x06, 0x07 accepted; 0x01, 0x03, 0x04, 0x05 dropped.
- **NodeTable:** apply_pos_full, apply_status; upsert_remote (Alive path does not overwrite position). No apply_tail1/2/info; no last_applied_tail_ref* in NodeEntry.

## Validation

- **test_native_nodetable:** test_beacon_logic, test_geo_beacon_codec, test_node_table_domain — **pass**.
- **devkit_e22_oled_gnss** build — **SUCCESS**.

## Out of scope / known unrelated issue

- **test_ble_transport_core** link error (undefined BLE symbols) is pre-existing and out of scope for this PR; not introduced by #438.

#438 is to be closed after this PR is merged.
