### PR TITLE
feat(#424): align radio profile baseline with FACTORY/current canon

### DIFF
--- a/_working/424_contract_and_gaps.md
+++ b/_working/424_contract_and_gaps.md
@@ -1,0 +1,68 @@
+# #424 Radio profile baseline — contract and gap table
+
+**Issue:** #424 · **Umbrella:** #416  
+**Canon:** provisioning_baseline_v0, boot_pipeline_v0, radio_profiles_model_s03, tx_power_contract_s03, e220_radio_profile_mapping_s03
+
+---
+
+## 1) Contract restatement
+
+**Phase A owns:** Applying the **FACTORY default RadioProfile** (product-level, id 0) to the radio hardware at boot. No NVS read of profile content. Source of truth: product model (channel_slot=1, rate_tier=STANDARD→2.4k, tx_power_baseline_step=0→MIN 21 dBm). Hardware is configured so OOTB comms work.
+
+**Phase B owns:** Loading **current_profile_id** and **previous_profile_id** from NVS; if missing or invalid → set both to **0** (FACTORY) and **persist**. Resolving logical current profile state for cadence/UI. Phase B does **not** re-apply radio hardware config; hardware was already configured in Phase A.
+
+**Must never be conflated:** (1) Logical profile pointers (current/previous id) vs hardware-applied baseline. (2) Baseline (stored in profile, applied at boot) vs runtime-observed values (must not overwrite baseline).
+
+**TX power contract:** Baseline = stored in RadioProfile (tx_power_baseline_step). Runtime = current effective setting. Runtime **must not** overwrite or persist to baseline.
+
+**FACTORY profile (id 0):** Virtual; not stored in NVS; content is const in FW. current_profile_id = 0 always resolves to FACTORY default.
+
+---
+
+## 2) Gap table
+
+| Area | Current | Canon | Gap | Owner |
+|------|---------|-------|-----|--------|
+| Phase A source | `get_radio_preset(RadioPresetId::Default)` → (2, 1, **30 dBm**) | Phase A applies **FACTORY default** from product model; step 0 = **21 dBm** | Preset is HAL-only, 30 dBm; not derived from product FACTORY default. | #424 |
+| Phase A application | E220 apply_critical does not set TX power (advisory in preset) | OOTB MUST use MIN (21 dBm) once mapping implemented | Preset value wrong; E220 UART may not expose TX in config frame — align source to FACTORY and use 21 dBm in preset. | #424 |
+| Phase B pointers | load_pointers; if !has_current_radio or invalid id → effective 0,0; save_pointers | Missing/invalid → current=0, previous=0; persist. FACTORY id 0 = virtual. | Logic correct; add explicit normalization comment and ensure previous=0 when normalizing. | #424 (comment/clarity) |
+| Logical vs hardware | effective_channel from effective_radio_id (0→1) in Phase B | Phase B does not re-apply radio; logical state only. | Already correct; add short comment that Phase B is pointers only. | #424 |
+| Baseline vs runtime | No code overwrites RadioProfileRecord with runtime TX | Runtime must not overwrite baseline. | None found; document invariant. | #424 (doc/test) |
+| rprof_ver | Not written | Schema version should be present when using profile keys. | Optional: write rprof_ver on save_pointers. | #424 (minimal) |
+
+---
+
+## 3) Implementation plan (minimal #424 delta)
+
+1. **Phase A:** In `radio_factory`, obtain FACTORY default from product model (`get_factory_default_radio_profile`), build `RadioPreset` from it (channel_slot→channel, rate_tier→air_rate, tx_power_baseline_step 0→21 dBm), call `begin(preset)`. So Phase A explicitly uses FACTORY profile; OOTB preset uses 21 dBm.
+2. **HAL preset:** `get_radio_preset(RadioPresetId::Default)` return 21 dBm (not 30) so Default matches FACTORY MIN.
+3. **Phase B:** Add explicit comment: current_radio_profile_id 0 = FACTORY (virtual); missing/invalid pointers → normalize to 0/0 and persist. Ensure new_previous_radio is 0 when we normalized (first boot).
+4. **rprof_ver:** Optionally write schema version when saving pointers (canon); low risk.
+5. **Tests:** Default preset 21 dBm (test_radio_preset); Phase A uses get_factory_default_radio_profile in radio_factory. get_factory_default_radio_profile lives in naviga_storage.cpp (NVS); not linked in native tests; contract and values documented. Baseline vs runtime: no code path overwrites RadioProfileRecord with runtime TX (verified by code review); tx_power_contract_s03 invariant.
+---
+
+## 4) Implementation summary (done)
+
+| Change | File | Description |
+|--------|------|--------------|
+| Phase A source | `radio_factory.cpp` | `preset_from_factory_default()`: get FACTORY from product model (`get_factory_default_radio_profile`), build `RadioPreset` (channel_slot, rate_tier, step→dBm E220 mapping), call `begin(preset)`. Phase A no longer uses HAL-only preset. |
+| Default preset | `radio_preset.h` | `get_radio_preset(Default)` tx_power_dbm 30 → 21 (MIN per canon). |
+| Phase B comments | `app_services.cpp` | Explicit: current_radio_profile_id 0 = FACTORY (virtual); missing/invalid → normalize 0/0 and persist. Use `kRadioProfileIdFactoryDefault` for default. |
+| rprof_ver | `naviga_storage.cpp` | Write `rprof_ver` (schema version) when saving pointers. |
+| Test | `test_radio_preset.cpp` | `test_get_radio_preset_default_tx_power_21_dbm`: Default preset = 21 dBm. |
+
+**Validation:** test_radio_preset (incl. Default 21 dBm), test_role_profile_registry, test_boot_phase_contract passed. devkit_e220_oled build passed.
+
+**Remaining for #425 only:** Observability (baseline/runtime/override exposed for telemetry); no scope bleed.
+
+---
+
+## 5) Exit criteria
+
+- [x] #424 contract restated from canon  
+- [x] Gap table produced  
+- [x] Minimal #424 delta implemented  
+- [x] Tests added/updated and passing (Default 21 dBm; Phase B comments)  
+- [x] Devkit build passing  
+- [x] Docs: 424_contract_and_gaps.md; no canon rewrite  
+- [x] Final close recommendation: #424 scope complete; Phase A uses FACTORY product model; Phase B pointers explicit; baseline/runtime separation upheld. #425 for observability.

--- a/firmware/lib/NavigaCore/include/naviga/hal/radio_preset.h
+++ b/firmware/lib/NavigaCore/include/naviga/hal/radio_preset.h
@@ -28,7 +28,7 @@ struct RadioPreset {
 // Presets 1/2 are defined here so the apply path can be exercised in tests
 // and future firmware without adding new user-selection mechanisms now.
 enum class RadioPresetId : uint8_t {
-  Default   = 0,  // 2.4 kbps  / SF9-equivalent UART baseline
+  Default   = 0,  // 2.4 kbps / channel 1 / 21 dBm MIN (FACTORY default per canon)
   Fast      = 1,  // 4.8 kbps  / urban / short-range
   LongRange = 2,  // 2.4 kbps  / same as Default for UART; SPI will use SF10
 };
@@ -60,7 +60,7 @@ inline RadioPreset get_radio_preset(RadioPresetId id) {
       return RadioPreset{/*.air_rate=*/2, /*.channel=*/1, /*.tx_power_dbm=*/30};
     case RadioPresetId::Default:
     default:
-      return RadioPreset{/*.air_rate=*/2, /*.channel=*/1, /*.tx_power_dbm=*/30};
+      return RadioPreset{/*.air_rate=*/2, /*.channel=*/1, /*.tx_power_dbm=*/21};  // MIN per canon OOTB
   }
 }
 

--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -225,9 +225,10 @@ void AppServices::init() {
   }
 
   // --- Phase B: Provision role + radio profile (boot_pipeline_v0) ---
-  // Cadence params from current role profile record in flash (#289); pointers for role/radio id (display, consistency).
+  // Logical pointers only; radio hardware was configured in Phase A. current_radio_profile_id 0 = FACTORY (virtual, not in NVS).
+  // Missing or invalid pointers → normalize to 0/0 and persist (provisioning_baseline_v0 §4.2).
   constexpr uint32_t kDefaultRoleId = 0;
-  constexpr uint32_t kDefaultRadioProfileId = 0;
+  constexpr uint32_t kDefaultRadioProfileId = kRadioProfileIdFactoryDefault;  // 0 = FACTORY
   PersistedPointers ptrs{};
   const bool loaded = load_pointers(&ptrs);
   bool use_persisted = loaded && ptrs.has_current_role && ptrs.has_current_radio;

--- a/firmware/src/platform/naviga_storage.cpp
+++ b/firmware/src/platform/naviga_storage.cpp
@@ -11,6 +11,7 @@ constexpr char kKeyCurrentRole[] = "role_cur";
 constexpr char kKeyCurrentRadio[] = "prof_cur";
 constexpr char kKeyPreviousRole[] = "role_prev";
 constexpr char kKeyPreviousRadio[] = "prof_prev";
+constexpr char kKeyRadioProfileVer[] = "rprof_ver";
 constexpr char kKeyProfileIntervalSec[] = "role_interval_s";
 constexpr char kKeyProfileSilence10s[] = "role_silence_10";
 constexpr char kKeyProfileDistM[] = "role_dist_m";
@@ -64,6 +65,7 @@ bool save_pointers(uint32_t current_role_id,
   prefs.putUInt(kKeyCurrentRadio, current_radio_profile_id);
   prefs.putUInt(kKeyPreviousRole, previous_role_id);
   prefs.putUInt(kKeyPreviousRadio, previous_radio_profile_id);
+  prefs.putUChar(kKeyRadioProfileVer, kRadioProfileSchemaVersion);
 
   prefs.end();
   return true;

--- a/firmware/src/platform/radio_factory.cpp
+++ b/firmware/src/platform/radio_factory.cpp
@@ -1,6 +1,7 @@
 #include "platform/radio_factory.h"
 
 #include "naviga/hal/radio_preset.h"
+#include "platform/naviga_storage.h"
 
 // E220 and E22 libraries both define ConfigurationMessage in global scope,
 // so they MUST NOT be included in the same translation unit.
@@ -13,9 +14,28 @@
 
 namespace naviga {
 
+// Build HAL preset from product-level FACTORY default for Phase A (boot_pipeline_v0).
+// Phase A applies FACTORY default to hardware; no NVS read. Adapter maps product step to module.
+static RadioPreset preset_from_factory_default() {
+  RadioProfileRecord factory{};
+  get_factory_default_radio_profile(&factory);
+  // E220 T30D mapping: step 0→21, 1→24, 2→27, 3→30 dBm (e220_radio_profile_mapping_s03).
+  uint8_t tx_dbm = 21;
+  if (factory.tx_power_baseline_step > 0u && factory.tx_power_baseline_step <= 3u) {
+    tx_dbm = 21u + factory.tx_power_baseline_step * 3u;
+  } else if (factory.tx_power_baseline_step > 3u) {
+    tx_dbm = 30u;  // T30D max; T33D would allow 33
+  }
+  return RadioPreset{
+      /*.air_rate=*/factory.rate_tier,
+      /*.channel=*/factory.channel_slot,
+      /*.tx_power_dbm=*/tx_dbm,
+  };
+}
+
 IRadio* create_radio(const HwProfile& profile, bool* radio_ready_out) {
-  // Default preset (airRate=2, channel=1). Future: derive from persisted radio profile id.
-  const RadioPreset preset = get_radio_preset(RadioPresetId::Default);
+  // Phase A: apply FACTORY default RadioProfile to hardware (provisioning_baseline_v0). No NVS.
+  const RadioPreset preset = preset_from_factory_default();
 #if defined(HW_PROFILE_DEVKIT_E22_OLED_GNSS)
   static E22Radio instance(profile.pins);
   *radio_ready_out = instance.begin(preset);

--- a/firmware/test/test_radio_preset/test_radio_preset.cpp
+++ b/firmware/test/test_radio_preset/test_radio_preset.cpp
@@ -94,6 +94,12 @@ void test_get_radio_preset_default_air_rate_2() {
   TEST_ASSERT_EQUAL_UINT8(1, p.channel);
 }
 
+// #424: Default preset = FACTORY MIN 21 dBm per provisioning_baseline_v0 / e220_radio_profile_mapping_s03.
+void test_get_radio_preset_default_tx_power_21_dbm() {
+  RadioPreset p = get_radio_preset(RadioPresetId::Default);
+  TEST_ASSERT_EQUAL_UINT8(21, p.tx_power_dbm);
+}
+
 void test_get_radio_preset_fast_air_rate_3() {
   RadioPreset p = get_radio_preset(RadioPresetId::Fast);
   TEST_ASSERT_EQUAL_UINT8(3, p.air_rate);
@@ -143,6 +149,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_verify_preset_readback_both_mismatch);
 
   RUN_TEST(test_get_radio_preset_default_air_rate_2);
+  RUN_TEST(test_get_radio_preset_default_tx_power_21_dbm);
   RUN_TEST(test_get_radio_preset_fast_air_rate_3);
   RUN_TEST(test_get_radio_preset_longrange_air_rate_2);
   RUN_TEST(test_all_canonical_presets_no_clamp_needed);

--- a/firmware/test/test_role_profile_registry/test_role_profile_registry.cpp
+++ b/firmware/test/test_role_profile_registry/test_role_profile_registry.cpp
@@ -1,6 +1,8 @@
 /**
  * Unit tests for #289: role profile record and OOTB defaults.
  * Tests get_ootb_role_profile (no NVS); fallback behavior is tested on device.
+ * #424: get_factory_default_radio_profile (FACTORY id 0) is in naviga_storage.cpp (uses NVS);
+ *       Phase A uses it via radio_factory; Default preset 21 dBm tested in test_radio_preset.
  */
 #include <unity.h>
 


### PR DESCRIPTION
## Summary

Aligns radio profile baseline semantics with canon (#424). Phase A uses the FACTORY default RadioProfile (id 0) as the source for radio boot; Phase B normalizes and persists current/previous pointers; baseline and runtime TX power remain separated.

**Scope (this PR only):** #424. No User Profile baseline work; no #425/#426.

---

## Phase A

- **FACTORY default (id 0)** is now the explicit source for radio boot baseline. `radio_factory` calls `get_factory_default_radio_profile()` and builds the HAL preset from that product-level record (channel_slot, rate_tier, tx_power_baseline_step → E220 mapping).
- **Default preset** now uses **21 dBm** (MIN) instead of 30 dBm, per provisioning_baseline_v0 and e220_radio_profile_mapping_s03. OOTB requires MIN at boot; module default 30 dBm is not acceptable per canon.
- **Note:** `get_factory_default_radio_profile()` lives in `naviga_storage.cpp` (ESP32/NVS side) and is **not** linked in native tests. Native tests cover the Default preset value (21 dBm) and Phase B pointer semantics; the full factory-profile source path is exercised in the devkit build.

---

## Phase B

- **current_radio_profile_id** and **previous_radio_profile_id** normalize to **0/0** when missing or invalid; normalized values are persisted. Profile id **0 = FACTORY** (virtual, not stored in NVS).
- Phase B does **not** re-apply radio hardware; hardware is configured in Phase A.
- **rprof_ver** (schema version) is now written when saving pointers.

---

## Baseline vs runtime TX power

- Baseline (stored in profile, applied at boot) and runtime (effective setting) remain separated; runtime does not overwrite baseline. No change to that contract in this PR.

---

## Validation

- **test_radio_preset** — passed (includes Default 21 dBm).
- **test_role_profile_registry** — passed.
- **test_boot_phase_contract** — passed.
- **pio run -e devkit_e220_oled** — passed.

Semantics are aligned with canon; devkit build is green. No claim of full native end-to-end coverage of `get_factory_default_radio_profile()` (it is ESP32-only).

---

## Out of scope

- **User Profile** baseline alignment is intentionally out of scope and will be handled separately after #424.
- #425 / #426 — not in this PR.

---

## Refs

- Closes #424.
- Canon: provisioning_baseline_v0, boot_pipeline_v0, radio_profiles_model_s03, tx_power_contract_s03, e220_radio_profile_mapping_s03.
