### PR TITLE
feat(#425): add traffic counters for runtime validation

### DIFF
--- a/docs/dev/debug_playbook.md
+++ b/docs/dev/debug_playbook.md
@@ -63,6 +63,7 @@ This is the fastest path from "it's broken" to "we know why".
 **Start with observability:**
 
 - enable logging v0 / key markers
+- **Traffic validation (#425):** Use `M1Runtime::traffic_counters()` for TX/RX by type (enqueue/sent/drop, slot replaced/starved, RX accept/reject). Reset with `reset_traffic_counters()` before a run; read after tick. See `firmware/src/domain/traffic_counters.h` and `_working/425_contract_and_gaps.md` §6.
 - confirm E220 module config matches expectations (RSSI append etc.)
 - verify power / wiring / UART pins
 - confirm radio params are consistent across devices (channel, address, rate)

--- a/firmware/src/app/m1_runtime.cpp
+++ b/firmware/src/app/m1_runtime.cpp
@@ -18,11 +18,13 @@ constexpr size_t kMaxRxPerTick = 4;
 
 const char* packet_log_type_str(domain::PacketLogType t) {
   switch (t) {
-    case domain::PacketLogType::CORE:  return "CORE";
-    case domain::PacketLogType::TAIL1: return "TAIL1";
-    case domain::PacketLogType::TAIL2: return "TAIL2";
-    case domain::PacketLogType::ALIVE: return "ALIVE";
-    case domain::PacketLogType::INFO:  return "INFO";
+    case domain::PacketLogType::CORE:     return "CORE";
+    case domain::PacketLogType::TAIL1:   return "TAIL1";
+    case domain::PacketLogType::TAIL2:   return "TAIL2";
+    case domain::PacketLogType::ALIVE:   return "ALIVE";
+    case domain::PacketLogType::INFO:    return "INFO";
+    case domain::PacketLogType::POS_FULL: return "POS_FULL";
+    case domain::PacketLogType::STATUS:   return "STATUS";
   }
   return "?";
 }
@@ -31,6 +33,24 @@ bool is_tail_type(domain::PacketLogType t) {
   return t == domain::PacketLogType::TAIL1 ||
          t == domain::PacketLogType::TAIL2 ||
          t == domain::PacketLogType::INFO;
+}
+
+static void increment_tx_sent_by_type(domain::TrafficCounters& c, domain::PacketLogType t) {
+  switch (t) {
+    case domain::PacketLogType::POS_FULL: c.tx_sent_pos_full++; break;
+    case domain::PacketLogType::ALIVE:   c.tx_sent_alive++;   break;
+    case domain::PacketLogType::STATUS:  c.tx_sent_status++;  break;
+    default: break;
+  }
+}
+
+static void increment_rx_ok_by_type(domain::TrafficCounters& c, domain::PacketLogType t) {
+  switch (t) {
+    case domain::PacketLogType::POS_FULL: c.rx_ok_pos_full++; break;
+    case domain::PacketLogType::ALIVE:   c.rx_ok_alive++;   break;
+    case domain::PacketLogType::STATUS:  c.rx_ok_status++;  break;
+    default: break;
+  }
 }
 
 } // namespace
@@ -66,6 +86,7 @@ void M1Runtime::init(uint64_t self_id,
   // #422 Path B: Status (Op/Info) lifecycle per packet_context_tx_rules_v0 §2a.
   beacon_logic_.set_min_status_interval_ms(30000);   // 30s anti-burst
   beacon_logic_.set_T_status_max_ms(300000);         // 300s = 10 min bounded refresh
+  beacon_logic_.set_traffic_counters(&traffic_counters_);
 
   self_fields_ = {};
   self_fields_.node_id = self_id;
@@ -140,6 +161,10 @@ void M1Runtime::tick(uint32_t now_ms) {
 
 const RadioSmokeStats& M1Runtime::stats() const {
   return stats_;
+}
+
+void M1Runtime::reset_traffic_counters() {
+  traffic_counters_ = domain::TrafficCounters{};
 }
 
 size_t M1Runtime::node_count() const {
@@ -240,6 +265,7 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
     const ChannelSenseResult result = channel_sense_->sense(kSenseTimeoutMs);
     if (result.state == ChannelSenseState::BUSY || result.state == ChannelSenseState::ERROR) {
       send_policy_.on_channel_busy(now_ms);
+      traffic_counters_.tx_drop_channel_busy++;
       if (instrumentation_log_fn_ && instrumentation_ctx_) {
         char line[96];
         if (is_tail_type(last_tx_type_)) {
@@ -266,8 +292,9 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
   if (ok) {
     stats_.tx_count++;
     stats_.last_tx_ms = now_ms;
-    // #422: Notify BeaconLogic when a P3 (Op/Info) was sent for status lifecycle (min_status_interval, T_status_max, bootstrap).
-    if (last_tx_type_ == domain::PacketLogType::TAIL2 || last_tx_type_ == domain::PacketLogType::INFO) {
+    increment_tx_sent_by_type(traffic_counters_, last_tx_type_);
+    // #422: Notify BeaconLogic when Node_Status was sent (status lifecycle: min_status_interval, T_status_max, bootstrap).
+    if (last_tx_type_ == domain::PacketLogType::STATUS) {
       beacon_logic_.on_status_sent(now_ms);
     }
     // Persist the seq16 that was actually sent (#417): Common prefix at payload offset 7-8, frame = header(2) + payload.
@@ -293,6 +320,7 @@ void M1Runtime::handle_tx(uint32_t now_ms) {
     log_event(now_ms, domain::LogEventId::RADIO_TX_OK, domain::LogLevel::kInfo, &kGeoBeaconMsgType, 1);
     pending_len_ = 0;
   } else {
+    traffic_counters_.tx_drop_send_fail++;
     if (instrumentation_log_fn_ && instrumentation_ctx_) {
       char line[96];
       if (is_tail_type(last_tx_type_)) {
@@ -334,6 +362,11 @@ void M1Runtime::handle_rx(uint32_t now_ms) {
     const bool updated = beacon_logic_.on_rx(now_ms, frame, out_len, stats_.last_rssi_dbm,
                                              node_table_, &rx_node_id, &rx_seq, &rx_pos_valid,
                                              &rx_type, &rx_core_seq);
+    if (updated) {
+      increment_rx_ok_by_type(traffic_counters_, rx_type);
+    } else {
+      traffic_counters_.rx_reject++;
+    }
     if (instrumentation_log_fn_ && instrumentation_ctx_) {
       const uint16_t from_short = domain::NodeTable::compute_short_id(rx_node_id);
       char line[100];

--- a/firmware/src/app/m1_runtime.h
+++ b/firmware/src/app/m1_runtime.h
@@ -8,6 +8,7 @@
 #include "domain/logger.h"
 #include "domain/node_table.h"
 #include "domain/nodetable_snapshot.h"
+#include "domain/traffic_counters.h"
 #include "naviga/hal/interfaces.h"
 #include "platform/ble_esp32_transport.h"
 #include "../../protocol/ble_status_bridge.h"
@@ -48,6 +49,10 @@ class M1Runtime {
   void tick(uint32_t now_ms);
 
   const RadioSmokeStats& stats() const;
+  /** #425: traffic validation counters (enqueue/sent/drop by type, RX accept/reject). */
+  const domain::TrafficCounters& traffic_counters() const { return traffic_counters_; }
+  void reset_traffic_counters();
+
   size_t node_count() const;
   uint16_t geo_seq() const;
   bool ble_connected() const;
@@ -99,6 +104,8 @@ class M1Runtime {
   uint32_t last_ble_update_ms_ = 0;
 
   RadioSmokeStats stats_{};
+  domain::TrafficCounters traffic_counters_{};
+
   // TX frame buffer: sized for the largest possible on-air frame.
   uint8_t pending_payload_[protocol::kMaxFrameSize] = {};
   size_t pending_len_ = 0;

--- a/firmware/src/domain/beacon_logic.cpp
+++ b/firmware/src/domain/beacon_logic.cpp
@@ -54,6 +54,7 @@ void BeaconLogic::enqueue_slot(size_t slot_idx,
   TxSlot& slot = slots_[slot_idx];
   if (slot.present) {
     slot.replaced_count++;
+    if (traffic_counters_) { traffic_counters_->tx_slot_replaced++; }
     // created_at_ms preserved intentionally (fairness: age from first enqueue)
   } else {
     slot.created_at_ms  = now_ms;
@@ -183,6 +184,7 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
       if (pos_len > 0) {
         enqueue_slot(kSlotPosFull, TxPriority::P0_MUST_PERIODIC, TxBestEffortClass::BE_LOW,
                      PacketLogType::POS_FULL, pos_frame, pos_len, now_ms, 0);
+        if (traffic_counters_) { traffic_counters_->tx_enqueue_pos_full++; }
         last_tx_ms_ = now_ms;
         pos_or_alive_enqueued = true;
       }
@@ -199,6 +201,7 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
       if (alive_len > 0) {
         enqueue_slot(kSlotAlive, TxPriority::P0_MUST_PERIODIC, TxBestEffortClass::BE_LOW,
                      PacketLogType::ALIVE, alive_frame, alive_len, now_ms, 0);
+        if (traffic_counters_) { traffic_counters_->tx_enqueue_alive++; }
         last_tx_ms_ = now_ms;
         pos_or_alive_enqueued = true;
       }
@@ -233,6 +236,7 @@ void BeaconLogic::update_tx_queue(uint32_t now_ms,
     if (status_len > 0) {
       enqueue_slot(kSlotStatus, TxPriority::P3_THROTTLED, TxBestEffortClass::BE_LOW,
                    PacketLogType::STATUS, status_frame, status_len, now_ms, 0);
+      if (traffic_counters_) { traffic_counters_->tx_enqueue_status++; }
       last_status_enqueue_ms_ = now_ms;
     }
   }
@@ -306,6 +310,7 @@ bool BeaconLogic::dequeue_tx(uint8_t* out,
   for (size_t i = 0; i < kTxSlotCount; ++i) {
     if (i != best_u && slots_[i].present) {
       slots_[i].replaced_count++;
+      if (traffic_counters_) { traffic_counters_->tx_starved++; }
     }
   }
 

--- a/firmware/src/domain/beacon_logic.h
+++ b/firmware/src/domain/beacon_logic.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "domain/node_table.h"
+#include "domain/traffic_counters.h"
 #include "../../protocol/geo_beacon_codec.h"
 #include "../../protocol/alive_codec.h"
 #include "../../protocol/packet_header.h"
@@ -186,6 +187,9 @@ class BeaconLogic {
   /** Returns true if any TX slot is present (queue non-empty). */
   bool has_pending_tx() const;
 
+  /** Optional #425 observability: when set, formation/dequeue update counters. */
+  void set_traffic_counters(TrafficCounters* c) { traffic_counters_ = c; }
+
   /** Direct read-only access to a slot for testing. */
   const TxSlot& slot(size_t slot_index) const { return slots_[slot_index]; }
 
@@ -221,6 +225,8 @@ class BeaconLogic {
 
   // Slot-based TX queue.
   TxSlot slots_[kTxSlotCount] = {};
+
+  TrafficCounters* traffic_counters_ = nullptr;
 
   // Allocate the next global seq16 and advance the counter.
   uint16_t next_seq16();

--- a/firmware/src/domain/traffic_counters.h
+++ b/firmware/src/domain/traffic_counters.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+
+namespace naviga {
+namespace domain {
+
+/**
+ * Debug counters for traffic validation (#425).
+ * Answers: what packet types are enqueued/sent/dropped, coalesce/replace/starve, RX accept/reject.
+ * No protocol or profile semantics; read via M1Runtime::traffic_counters().
+ */
+struct TrafficCounters {
+  // TX formation (BeaconLogic)
+  uint32_t tx_enqueue_pos_full = 0;
+  uint32_t tx_enqueue_alive    = 0;
+  uint32_t tx_enqueue_status   = 0;
+  uint32_t tx_slot_replaced    = 0;  ///< Enqueue replaced an existing slot (coalesce).
+  uint32_t tx_starved          = 0;  ///< Dequeue chose one slot; others got starvation increment.
+
+  // TX outcome (M1Runtime: after send attempt)
+  uint32_t tx_sent_pos_full = 0;
+  uint32_t tx_sent_alive    = 0;
+  uint32_t tx_sent_status   = 0;
+  uint32_t tx_drop_channel_busy = 0;
+  uint32_t tx_drop_send_fail   = 0;
+
+  // RX (M1Runtime: after on_rx)
+  uint32_t rx_ok_pos_full = 0;
+  uint32_t rx_ok_alive    = 0;
+  uint32_t rx_ok_status   = 0;
+  uint32_t rx_reject      = 0;  ///< Decode or validate failed (unknown type / bad payload).
+};
+
+}  // namespace domain
+}  // namespace naviga

--- a/firmware/test/test_beacon_logic/test_beacon_logic.cpp
+++ b/firmware/test/test_beacon_logic/test_beacon_logic.cpp
@@ -22,6 +22,7 @@ using naviga::domain::NodeTable;
 using naviga::domain::NodeEntry;
 using naviga::domain::PacketLogType;
 using naviga::domain::SelfTelemetry;
+using naviga::domain::TrafficCounters;
 using naviga::domain::TxPriority;
 using naviga::domain::TxBestEffortClass;
 using naviga::domain::kSlotPosFull;
@@ -1501,6 +1502,52 @@ void test_txq_priority_ordering_p0_beats_all() {
   TEST_ASSERT_FALSE(logic.has_pending_tx());
 }
 
+// #425: TrafficCounters observability — formation/dequeue update counters when set.
+void test_traffic_counters_enqueue_and_slot_replaced() {
+  BeaconLogic logic;
+  logic.set_min_interval_ms(1000);
+  logic.set_max_silence_ms(30000);
+  TrafficCounters c{};
+  logic.set_traffic_counters(&c);
+
+  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
+  GeoBeaconFields self = make_self_fields(node_id, true);
+  SelfTelemetry telem{};
+
+  logic.update_tx_queue(1000, self, telem, true);
+  TEST_ASSERT_EQUAL_UINT32(1, c.tx_enqueue_pos_full);
+  TEST_ASSERT_EQUAL_UINT32(0, c.tx_slot_replaced);
+
+  logic.update_tx_queue(2000, self, telem, true);
+  TEST_ASSERT_EQUAL_UINT32(2, c.tx_enqueue_pos_full);
+  TEST_ASSERT_EQUAL_UINT32(1, c.tx_slot_replaced);
+}
+
+void test_traffic_counters_starved() {
+  BeaconLogic logic;
+  logic.set_min_interval_ms(1000);
+  logic.set_max_silence_ms(30000);
+  TrafficCounters c{};
+  logic.set_traffic_counters(&c);
+
+  const uint64_t node_id = 0x0000AABBCCDDEEFFULL;
+  GeoBeaconFields self = make_self_fields(node_id, true);
+  SelfTelemetry telem{};
+  telem.has_battery = true;
+  telem.battery_percent = 90;
+
+  logic.update_tx_queue(1000, self, telem, false);
+  logic.update_tx_queue(1000, self, telem, true);
+  TEST_ASSERT_TRUE(logic.slot(kSlotPosFull).present);
+  TEST_ASSERT_TRUE(logic.slot(kSlotStatus).present);
+  TEST_ASSERT_EQUAL_UINT32(0, c.tx_starved);
+
+  uint8_t buf[65] = {};
+  size_t out_len = 0;
+  logic.dequeue_tx(buf, sizeof(buf), &out_len);
+  TEST_ASSERT_EQUAL_UINT32(1, c.tx_starved);
+}
+
 int main(int argc, char** argv) {
   UNITY_BEGIN();
   RUN_TEST(test_tx_cadence);
@@ -1571,5 +1618,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_txq_p2_tail1_before_p3_operational_informative);
   RUN_TEST(test_txq_starvation_increments_replaced_count);
   RUN_TEST(test_txq_priority_ordering_p0_beats_all);
+  RUN_TEST(test_traffic_counters_enqueue_and_slot_replaced);
+  RUN_TEST(test_traffic_counters_starved);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Adds **observability for traffic validation** only: structured `TrafficCounters` and instrumentation fixes so runtime behavior can be checked against traffic_model_v0 and packet_context_tx_rules_v0. **No protocol or profile semantics changed.** This is validation/debug support, not a protocol redesign.

Closes #425 (S03 P1/P2 observability). Umbrella: #416.

---

## Motivation: runtime questions we could not answer before

The work was driven by 7 concrete runtime questions that could not be answered confidently from existing logs/counters:

1. What packet types are **sent** and in what proportion?
2. What types are **received** and how many **accepted vs rejected**?
3. How often are TX slots **replaced** (coalesce) vs **starved**?
4. Is **Status throttling** (min_interval, T_status_max, no-hitchhiking) behaving?
5. How many TX packets are **dropped** and for what reason (channel busy vs send failure)?
6. **Cadence:** enqueue vs send by type?
7. Do we see only **supported packet types** on RX and how many **rejected**?

---

## What was added

### Structured counters: `domain::TrafficCounters` (`firmware/src/domain/traffic_counters.h`)

- **TX formation (BeaconLogic):** `tx_enqueue_pos_full`, `tx_enqueue_alive`, `tx_enqueue_status`; `tx_slot_replaced`; `tx_starved`.
- **TX outcome (M1Runtime):** `tx_sent_pos_full`, `tx_sent_alive`, `tx_sent_status`; `tx_drop_channel_busy`, `tx_drop_send_fail`.
- **RX (M1Runtime):** `rx_ok_pos_full`, `rx_ok_alive`, `rx_ok_status`; `rx_reject`.

**API:** `M1Runtime::traffic_counters()` (read), `M1Runtime::reset_traffic_counters()` (e.g. before a bench run). BeaconLogic receives an optional pointer via `set_traffic_counters()` from `M1Runtime::init()`.

### Instrumentation fixes (no behavior change to protocol/profile)

- **`packet_log_type_str`:** Now handles `POS_FULL` and `STATUS` so instrumentation logs show correct type names instead of "?".
- **`on_status_sent`:** Now triggered when `last_tx_type_ == STATUS` (was TAIL2/INFO), so Node_Status lifecycle (min_status_interval, T_status_max, bootstrap) is correct.

---

## Validation

- **`test_beacon_logic`:** 61 tests passed, including:
  - `test_traffic_counters_enqueue_and_slot_replaced`
  - `test_traffic_counters_starved`
- **devkit_e220_oled** build: success.

---

## Out of scope (unchanged)

- **No protocol or profile semantics changed.** No reopen of #417–#424 or #435/#438/#443.
- **#426** remains the place for broader current_state / runtime documentation. This PR only adds counters and the debug-playbook pointer.
