### PR TITLE
fix(#448): move NodeTable snapshot buffer off loopTask stack

### DIFF
--- a/firmware/src/app/app_services.cpp
+++ b/firmware/src/app/app_services.cpp
@@ -51,6 +51,9 @@ uint32_t gnss_diag_next_ms = 0;
 SelfUpdatePolicy self_policy;
 IRadio* radio = nullptr;
 
+// #448: single static buffer for NodeTable snapshot load/save; avoids 8KB on loopTask stack.
+static uint8_t g_nodetable_snapshot_buf[kMaxNodeTableSnapshotBytes];
+
 platform::ArduinoClock clock_;
 platform::ArduinoLogger logger_;
 platform::DefaultDeviceIdProvider device_id_provider_;
@@ -349,11 +352,9 @@ void AppServices::init() {
   }
   // #418: restore NodeTable from snapshot (after local identity known). Absent/corrupt => clean start.
   {
-    constexpr size_t kSnapshotBufSize = naviga::kMaxNodeTableSnapshotBytes;
-    uint8_t buf[kSnapshotBufSize];
     size_t len = 0;
-    if (load_nodetable_snapshot(buf, kSnapshotBufSize, &len) && len > 0) {
-      runtime_.restore_nodetable_snapshot(buf, len);
+    if (load_nodetable_snapshot(g_nodetable_snapshot_buf, kMaxNodeTableSnapshotBytes, &len) && len > 0) {
+      runtime_.restore_nodetable_snapshot(g_nodetable_snapshot_buf, len);
     }
   }
   provisioning_->set_instrumentation_flag(&instrumentation_enabled_);
@@ -508,10 +509,8 @@ void AppServices::tick(uint32_t now_ms) {
   constexpr uint32_t kMinNodetableSaveIntervalMs = 30000U;
   if (runtime_.nodetable_dirty() &&
       (last_nodetable_save_ms_ == 0 || (now_ms - last_nodetable_save_ms_) >= kMinNodetableSaveIntervalMs)) {
-    constexpr size_t kSnapshotBufSize = naviga::kMaxNodeTableSnapshotBytes;
-    uint8_t buf[kSnapshotBufSize];
-    const size_t len = runtime_.build_nodetable_snapshot(buf, kSnapshotBufSize);
-    if (len > 0 && save_nodetable_snapshot(buf, len)) {
+    const size_t len = runtime_.build_nodetable_snapshot(g_nodetable_snapshot_buf, kMaxNodeTableSnapshotBytes);
+    if (len > 0 && save_nodetable_snapshot(g_nodetable_snapshot_buf, len)) {
       runtime_.clear_nodetable_dirty();
       last_nodetable_save_ms_ = now_ms;
     }


### PR DESCRIPTION
## Summary
Minimal fix for boot-time `loopTask` stack overflow on `devkit_e22_oled_gnss` (blocks #447).

## Cause
`AppServices::init()` and `tick()` each used an 8KB stack-allocated buffer for NodeTable snapshot load/save. ESP32 Arduino `loopTask` default stack is 8KB; the init path overflowed before reaching operational state.

## Change
- **Single file:** `firmware/src/app/app_services.cpp`
- **One file-static buffer:** `g_nodetable_snapshot_buf[kMaxNodeTableSnapshotBytes]` (8KB in BSS).
- **Restore path (init):** use `g_nodetable_snapshot_buf` in `load_nodetable_snapshot` / `restore_nodetable_snapshot`.
- **Save path (tick):** use `g_nodetable_snapshot_buf` in `build_nodetable_snapshot` / `save_nodetable_snapshot`.

No change to snapshot format, persistence API, or task stack size. Snapshot semantics unchanged.

## Verification
- `pio run -e devkit_e22_oled_gnss` ✅
- One-board flash + serial boot verification: **pending** (run after merge or when HW is available; expect `hw_profile: devkit_e22_oled_gnss` then Phase A/B/C and normal loop).

Closes #448 (after HW boot check). Unblocks #447 trusted rerun.

Made with [Cursor](https://cursor.com)