### PR TITLE
docs: set up S04 iteration for BLE canon review and slicing

### DIFF
--- a/_working/ITERATION.md
+++ b/_working/ITERATION.md
@@ -1,16 +1,38 @@
-S03__2026-03__Execution.v1
+S04__2026-03__BLE_Promotion_and_Slicing.v1
 
-Work Area: Implementation (+ Test allowed)
-Tech Area: Firmware, Protocol, Radio, Persistence, Testing
-Scope: Implement canon slice per #416; start with P0 (#417–#422)
+Work Area: Planning / Design / Canon promotion prep (not Implementation by default)
+Tech Area: BLE, Mobile contract, NodeTable export/read/update, Profiles/config, Discovery/versioning
+
+Scope:
+- Use merged BLE WIP as the source artifact for review: docs/product/wip/areas/mobile/ble_contract_s04_v0.md
+- Verify readiness against promotion criteria stated in that doc
+- Prepare canon promotion decision (do not promote in this setup)
+- Prepare implementation slicing only after canon readiness is confirmed
+
+Explicit non-scope:
+- No final byte-level payload work in this setup
+- No final GATT/UUID work in this setup
+- No firmware/mobile implementation in this setup
+- No JOIN/Mesh expansion
+- Legacy BLE remains non-authoritative; not reintroduced unless explicitly planned
 
 Links:
-- Issue/Epic: #416
-- P0: #417, #418, #419, #420, #421, #422
-- Referenced trackers: #296, #355
+- Issue/Umbrella: #460
+- BLE WIP (input artifact, not promoted yet): docs/product/wip/areas/mobile/ble_contract_s04_v0.md — #361
 
-Definition of Done:
-- P0 complete + CI green + bench sanity evidence captured
+Order (strict):
+1. BLE WIP integrity / canon-promotion review first
+2. Canon-promotion decision second
+3. Slicing of implementation tasks third (only after canon readiness)
+4. Implementation work in later prompts/issues
+
+Definition of Done (S04 setup phase):
+- Active S04 iteration artifact exists (this file)
+- S04 umbrella/planning issue exists or is updated
+- BLE canon-promotion workstream is explicitly framed as first workstream
+- Next execution prompts can proceed without ambiguity
 
 Notes:
-- Execution umbrella #416 (not planning #351). Product specs stay in docs/product/** and docs/product/wip/**.
+- S04 is not a coding iteration by default; it starts with design/promotion/slicing preparation.
+- M1Runtime is the wiring/composition point; domain stays radio-agnostic.
+- Product specs stay in docs/product/** and docs/product/wip/**; do not treat OOTB/UI as normative source.

--- a/_working/README.md
+++ b/_working/README.md
@@ -77,5 +77,5 @@ This keeps the root small and ready for the next phase without losing history.
 
 ## Current state
 
-- **Iteration:** See first line of [ITERATION.md](ITERATION.md). (S03 is closed; structure is ready for the next phase.)
+- **Iteration:** See first line of [ITERATION.md](ITERATION.md). (S04 active: planning/design — BLE canon-promotion and slicing prep.)
 - **Evidence index:** See [hw_tests/](hw_tests/) subfolders; each run typically has a `notes.md` with issue links.

--- a/_working/issues/body/issue_s04_umbrella_body.md
+++ b/_working/issues/body/issue_s04_umbrella_body.md
@@ -1,0 +1,55 @@
+# S04: BLE canon promotion and slicing (planning umbrella)
+
+## Objective
+
+S04 is the **post-S03 planning/design iteration**. It is **not** a coding iteration by default. This umbrella frames the S04 phase and makes the **BLE WIP → canon-promotion** path the first explicit workstream.
+
+- **Canon promotion first:** Review the merged BLE WIP against its promotion criteria; decide promotion to canon only when ready.
+- **Slicing second:** Implementation tasks are sliced only after the BLE contract is canon-ready (or explicitly deferred).
+- **Implementation later:** Firmware/mobile implementation happens in later prompts/issues, not in this umbrella.
+
+---
+
+## Scope
+
+| Workstream | Description | Order |
+|------------|-------------|--------|
+| **1 — BLE WIP → canon review** | Use [ble_contract_s04_v0.md](docs/product/wip/areas/mobile/ble_contract_s04_v0.md) as input artifact. Verify readiness against promotion criteria (§14 of that doc). Do **not** promote in S04 setup; promotion is a separate decision after review. | First |
+| **2 — Canon promotion decision** | If review confirms readiness: promote BLE contract to canon per docs promotion policy. If not: document gaps and defer. | Second |
+| **3 — Implementation slicing** | Only after canon readiness (or explicit deferral): slice implementation tasks for BLE/firmware/mobile. | Third |
+| **4 — Implementation** | Carried out in later issues/PRs; not part of this planning umbrella. | Later |
+
+---
+
+## Input artifact (WIP, not promoted yet)
+
+- **Doc:** [docs/product/wip/areas/mobile/ble_contract_s04_v0.md](docs/product/wip/areas/mobile/ble_contract_s04_v0.md)
+- **Track:** [#361](https://github.com/AlexanderTsarkov/naviga-app/issues/361)
+- **Status:** WIP / Candidate. Promotion to canon only after review and explicit decision.
+
+---
+
+## Non-scope (S04 setup and this umbrella)
+
+- No final byte-level payload or GATT/UUID work in S04 setup
+- No firmware/mobile implementation in this phase
+- No JOIN/Mesh expansion
+- No reopening of S03 issues/umbrellas
+- Legacy BLE remains non-authoritative; not reintroduced unless explicitly planned
+
+---
+
+## Definition of done (S04 setup phase)
+
+- [ ] S04 iteration artifact exists (_working/ITERATION.md)
+- [ ] S04 umbrella (this issue) exists and is linked
+- [ ] BLE canon-promotion workstream is explicitly framed as first workstream
+- [ ] Next execution prompts can proceed without ambiguity
+
+---
+
+## References
+
+- **Iteration artifact:** `_working/ITERATION.md` (first line: S04__2026-03__BLE_Promotion_and_Slicing.v1)
+- **BLE gate (S03):** [ble_snapshot_s04_gate.md](docs/product/wip/areas/mobile/ble_snapshot_s04_gate.md) — S04 entry checklist
+- **Constraints:** M1Runtime = wiring point; domain radio-agnostic; OOTB/UI not normative (see [ai_model_policy](docs/dev/ai_model_policy.md))

--- a/docs/product/current_state.md
+++ b/docs/product/current_state.md
@@ -1,7 +1,7 @@
 # Current product state
 
-**Last updated:** 2026-03-12  
-**Iteration tag:** S03 execution (post–#416)  
+**Last updated:** 2026-03-14  
+**Iteration tag:** S04 planning (BLE canon-promotion and slicing prep)  
 **Scope:** Embedded-first (firmware → radio → domain → BLE bridge → mobile later).
 
 ---
@@ -67,6 +67,7 @@
 
 ## Next focus
 
+- **S04 (planning):** BLE WIP → canon review and promotion decision first; then implementation slicing; implementation work in later issues. Umbrella [#460](https://github.com/AlexanderTsarkov/naviga-app/issues/460); input artifact [ble_contract_s04_v0.md](wip/areas/mobile/ble_contract_s04_v0.md) (WIP, #361).
 - **Post–S03:** Docs cleanup and legacy migration [#278](https://github.com/AlexanderTsarkov/naviga-app/issues/278) (PR-1–PR-3 landed); planning track [#296](https://github.com/AlexanderTsarkov/naviga-app/issues/296) as needed.
 - Channel discovery / selection and AutoPower: post–V1-A ([#175](https://github.com/AlexanderTsarkov/naviga-app/issues/175), [#180](https://github.com/AlexanderTsarkov/naviga-app/issues/180)).
 


### PR DESCRIPTION
## Summary

- Establish **S04** as the post-S03 planning/design iteration (not a coding iteration by default).
- Make **BLE canon-promotion** the first explicit workstream: review WIP → promotion decision → slicing → implementation later.

## Scope

- **Iteration artifact:** `_working/ITERATION.md` updated to S04__2026-03__BLE_Promotion_and_Slicing.v1 with scope, order, and DoD.
- **Umbrella/planning issue:** [#460](https://github.com/AlexanderTsarkov/naviga-app/issues/460) created and linked; BLE WIP → canon review is the first workstream.
- **Minimal inventory:** `_working/README.md` and `docs/product/current_state.md` updated so S04 is discoverable and Next focus points to S04 BLE path.
- **Issue body draft:** `_working/issues/body/issue_s04_umbrella_body.md` added for reference/audit.

## Non-scope

- No BLE canon promotion in this PR (WIP remains WIP).
- No implementation work; no implementation subtasks created.

## Why now

- S03 is closed; docs/_working cleanup is complete.
- Repo is ready for the next phase boundary; this PR sets the S04 planning frame so later prompts can execute within it.
