### PR TITLE
docs(#466): document node_name label constraints

### DIFF
--- a/docs/product/areas/mobile/contract/ble_contract_s04_v0.md
+++ b/docs/product/areas/mobile/contract/ble_contract_s04_v0.md
@@ -109,6 +109,17 @@ Not a blind RAM dump; not aggressive early pruning. Broad product-facing contrac
 - **Remote human-readable aliases** stored only for the user/app (mobile-local) are **not** part of the BLE contract; they belong to future mobile-local persistence and UI logic. Do not mix that into #361 BLE contract.
 - **Remote local alias persistence** (on-node) is not in scope.
 
+### 9.1 node_name label constraints (S04 #466)
+
+`node_name` is a **short display label** for map/list/discovery. Implementations must enforce:
+
+- **Product/UI limit:** max **12 characters** (user-facing).
+- **Storage/transport ceiling:** max **24 bytes UTF-8** (BLE payload and node storage).
+- **Allowed characters:** Latin letters, Cyrillic letters, digits `0`–`9`, symbols: `-`, `_`, `#`, `=`, `@`, `+`.
+- **Disallowed:** emoji/pictograms, control characters, and any symbol not in the allowlist above.
+
+Rationale: compact readable label, predictable BLE/storage footprint, and a future radio-friendly upper bound.
+
 ---
 
 ## 10. Profiles contract

--- a/docs/product/areas/nodetable/policy/identity_naming_persistence_eviction_v0.md
+++ b/docs/product/areas/nodetable/policy/identity_naming_persistence_eviction_v0.md
@@ -20,9 +20,10 @@ This document is the **canonical reference** for the S03 "Identity + Naming + Pe
 
 ## 2) Human-readable node name (node_name)
 
-- **node_name:** Human-readable name for a node.
+- **node_name:** Short display label for a node (map/list/discovery).
   - **S03 scope:** Self-only. Set via BLE, persisted in NVS on the device. Remote entries usually empty (no over-air propagation in S03).
   - **Sxx (future):** Remote node_name may be populated from over-air propagation (e.g. session or Informative); when present, it is the **authoritative** value.
+- **Label constraints (S04 #466):** **Product/UI limit:** max 12 characters. **Storage/transport ceiling:** max 24 bytes UTF-8. **Allowed:** Latin letters, Cyrillic letters, digits `0`–`9`, symbols `-`, `_`, `#`, `=`, `@`, `+`. **Disallowed:** emoji/pictograms, control characters, symbols outside the allowlist. Rationale: compact readable label, predictable BLE/storage footprint, future radio-friendly upper bound.
 - **Authority rule:** Node-reported name is **authoritative** and **replaces** any previously stored local phone name for that node. If the node (or self via BLE) provides a name, that value wins.
 - **UI fallback order:** `node_name` (authoritative) → local phone name (only if no authoritative name) → short_id.
 

--- a/docs/product/areas/nodetable/policy/nodetable_master_field_table_v0.md
+++ b/docs/product/areas/nodetable/policy/nodetable_master_field_table_v0.md
@@ -15,7 +15,7 @@ This table is the single authoritative classification for NodeTable-related fiel
 | short_id | identity | Yes | Yes | Yes | Yes | Product-facing; CRC16-derived. |
 | is_self | derived | Yes | Yes | No | Derived | From (node_id == local identity). |
 | short_id_collision | derived | Yes | Yes | No | Derived | UI safeguard; recomputed. |
-| node_name | identity/name | Yes | Yes | Yes | Yes | Single canonical name (self + remote). |
+| node_name | identity/name | Yes | Yes | Yes | Yes | Short display label; max 12 chars (product/UI), 24 B UTF-8 (storage/transport); allowlist per identity_naming_persistence_eviction_v0 §2. |
 
 ---
 
@@ -105,7 +105,7 @@ packet_header, payloadVersion — not stored as product NodeTable fields; packin
 - **Aligned:** node_id, short_id, is_self, short_id_collision, pos (lat_e7, lon_e7, pos_age_s, pos_flags, sats), battery_percent, uptime_sec, max_silence_10s, hw_profile_id, fw_version_id, last_rx_rssi, last_seen_ms, last_seq (in NodeTable only; not BLE).
 - **BLE:** last_seq removed from BLE export; snr_last added (sentinel 127 = NA).
 - **Legacy ref:** Kept in NodeEntry for decoder only; not in BLE, not in persistence.
-- **node_name:** Added to NodeEntry; in persistence snapshot; BLE export per format.
+- **node_name:** Added to NodeEntry; in persistence snapshot; BLE export per format. Label constraints: 12 chars / 24 bytes UTF-8, allowlist (Latin, Cyrillic, digits, `- _ # = @ +`); see [identity_naming_persistence_eviction_v0](identity_naming_persistence_eviction_v0.md) §2 and [ble_contract_s04_v0](../../mobile/contract/ble_contract_s04_v0.md) §9.1.
 - **Stubs:** pos_fix_type, pos_accuracy_bucket, charging, battery_est_rem_time, tx_power_step, channel_throttle_step, role_id — added as stubs where minimal.
 
 ---


### PR DESCRIPTION
Documents the agreed `node_name` label constraints after Slice 4 implementation (#466 / PR #471).

**Changes:**
- **BLE contract (§9.1):** Short display label; max 12 characters (product/UI), max 24 bytes UTF-8 (storage/transport); allowlist and disallowed; rationale.
- **NodeTable identity/naming policy (§2):** Same constraints and rationale; explicit product/UI vs storage/transport.
- **Master field table:** node_name row and §9 note reference the 12-char/24-byte rule and allowlist; link to identity_naming and BLE contract.

**No code changes.** No BLE contract redesign. Clarifies product/UI limit vs storage/transport byte cap.
